### PR TITLE
Encre core: Add Callable for invoke, mapping, and binding functions

### DIFF
--- a/packages/core/src/record/callable.ts
+++ b/packages/core/src/record/callable.ts
@@ -1,0 +1,616 @@
+import {
+  RecordId,
+  RecordType,
+  SecretFields,
+  SerializedFields,
+  SerializedKeyAlias,
+  keyToJson,
+  mapKeyTypes,
+  mapKeys,
+} from "../load/keymap";
+import {
+  Serializable,
+  Serialized,
+  SerializedInputRecord,
+} from "../load/serializable";
+import { AsyncCallError, AsyncCaller } from "../utils/asyncCaller";
+
+export type CallableConfigFields = {
+  [key: string]: unknown;
+};
+
+export type CallableConfig = {
+  /**
+   * Name of the callable class.
+   */
+  name?: string;
+
+  /**
+   * Tags for this call and any sub-calls.
+   */
+  tags?: string[];
+
+  /**
+   * Metadata for this call and any sub-calls.
+   */
+  metadata?: CallableConfigFields;
+
+  /**
+   * Callbacks for this calls and any sub-calls.
+   * TODO: Add callbacks.
+   */
+  callbacks?: any;
+};
+
+export type CallableFunc<CallInput, CallOutput> = (
+  input: CallInput
+) => CallOutput | Promise<CallOutput>;
+
+export type CallableBindArgs<
+  CallInput,
+  CallOutput,
+  CallOptions extends CallableConfig,
+> = {
+  bound: Callable<CallInput, CallOutput, CallOptions>;
+  kwargs: Partial<CallOptions>;
+  config: CallableConfig;
+};
+
+export type CallableBatchOptions = {
+  maxConcurrency?: number;
+  returnExceptions?: boolean;
+};
+
+export abstract class Callable<
+  CallInput = unknown,
+  CallOutput = unknown,
+  CallOptions extends CallableConfig = CallableConfig,
+> extends Serializable {
+  _isCallable = true;
+
+  abstract invoke(
+    input: CallInput,
+    options?: Partial<CallOptions>
+  ): Promise<CallOutput>;
+
+  protected async _callWithConfig<T extends CallInput>(
+    func: (input: T) => Promise<CallOutput>,
+    input: T,
+    options?: Partial<CallOptions>
+  ): Promise<CallOutput> {
+    let output: CallOutput;
+
+    /*eslint no-useless-catch: "warn"*/
+    try {
+      output = await func.bind(this)(input, options);
+    } catch (e) {
+      throw e;
+    }
+
+    return output;
+  }
+
+  protected async _batchWithConfig<T extends CallInput>(
+    func: (
+      input: T[],
+      options?: Partial<CallOptions>[],
+      batchOptions?: CallableBatchOptions
+    ) => Promise<(CallOutput | Error)[]>,
+    inputs: T[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]> {
+    const optionsList: Partial<CallOptions>[] = this._getOptionsList(
+      options ?? {},
+      inputs.length
+    );
+
+    let outputs: (CallOutput | Error)[];
+    try {
+      outputs = await func(inputs, optionsList, batchOptions);
+    } catch (e) {
+      throw e;
+    }
+
+    return outputs;
+  }
+
+  protected _getOptionsList(
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    repeatTimes?: number
+  ): Partial<CallOptions>[] {
+    if (!options) return [];
+
+    if (!Array.isArray(options)) {
+      return Array.from({ length: repeatTimes || 1 }, () => options);
+    }
+
+    if (repeatTimes && options.length !== repeatTimes) {
+      throw new Error(
+        `Passed "options" must be an array with the same length as the inputs, but got ${options.length} options for ${repeatTimes} inputs`
+      );
+    }
+
+    return options;
+  }
+
+  withConfig(
+    config: CallableConfig
+  ): CallableBind<CallInput, CallOutput, CallOptions> {
+    return new CallableBind({ bound: this, kwargs: {}, config });
+  }
+
+  withFallbacks(fields: {
+    fallbacks: Callable<CallInput, CallOutput>[];
+  }): CallableWithFallbacks<CallInput, CallOutput> {
+    return new CallableWithFallbacks<CallInput, CallOutput>({
+      callable: this,
+      fallbacks: fields.fallbacks,
+    });
+  }
+
+  bind(
+    kwargs: Partial<CallOptions>
+  ): Callable<CallInput, CallOutput, CallOptions> {
+    return new CallableBind({ bound: this, kwargs, config: {} });
+  }
+
+  map(): Callable<CallInput[], CallOutput[], CallOptions> {
+    return new CallableEach({ bound: this });
+  }
+
+  /**
+   * Batch calls invoke N times, where N is the length of inputs.
+   * Subclasses would override this method with different arguments and returns.
+   * @param inputs Array of inputs in each call in a batch.
+   * @param options Either a single call options to apply to each call or an array of options for each call.
+   * @param batchOptions.maxConcurrency Max number of calls to run at once.
+   * @param batchOptions.returnExceptions Whether to return errors rather than throwing on the first error.
+   * @returns An arrays of CallOutputs, or mixed CallOutputs and Errors (if returnExceptions is true).
+   */
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions?: false }
+  ): Promise<CallOutput[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions: true }
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]> {
+    const optionsList: Partial<CallOptions>[] = this._getOptionsList(
+      options ?? {},
+      inputs.length
+    );
+
+    const caller = new AsyncCaller({
+      maxConcurrency: batchOptions?.maxConcurrency,
+      onFailedAttempt: (e: AsyncCallError) => {
+        throw e as Error;
+      },
+    });
+
+    const batchCalls: Promise<CallOutput | Error>[] = inputs.map((input, i) =>
+      caller.call(async () => {
+        try {
+          const result: CallOutput = await this.invoke(input, optionsList[i]);
+          return result;
+        } catch (e) {
+          if (batchOptions?.returnExceptions) {
+            return e as Error;
+          }
+          throw e as Error;
+        }
+      })
+    );
+
+    return Promise.all(batchCalls);
+  }
+
+  async toRecord(
+    outputs: CallOutput,
+    parent?: RecordId | undefined
+  ): Promise<Serialized> {
+    return super.toRecord(outputs, parent);
+  }
+
+  protected _splitCallableOptionsFromCallOptions(
+    options: Partial<CallOptions> = {}
+  ): [CallableConfig, Omit<Partial<CallOptions>, keyof CallableConfig>] {
+    const callableOptions: CallableConfig = {
+      name: options.name,
+      tags: options.tags,
+      metadata: options.metadata,
+      callbacks: options.callbacks,
+    };
+
+    const callOptionsCopy: Partial<CallOptions> = { ...options };
+    delete callOptionsCopy.name;
+    delete callOptionsCopy.tags;
+    delete callOptionsCopy.metadata;
+    delete callOptionsCopy.callbacks;
+
+    return [callableOptions, callOptionsCopy];
+  }
+}
+
+export class CallableBind<
+  CallInput,
+  CallOutput,
+  CallOptions extends CallableConfig,
+> extends Callable<CallInput, CallOutput, CallOptions> {
+  _isCallable = true;
+
+  _isSerializable = true;
+
+  _namespace: string[] = ["record", "callable"];
+
+  static _name(): string {
+    return "CallableBind";
+  }
+
+  bound: Callable<CallInput, CallOutput, CallOptions>;
+
+  config: CallableConfig;
+
+  protected kwargs: Partial<CallOptions>;
+
+  constructor(fields: CallableBindArgs<CallInput, CallOutput, CallOptions>) {
+    super(fields);
+    this.bound = fields.bound;
+    this.kwargs = fields.kwargs;
+    this.config = fields.config;
+  }
+
+  protected _mergeConfig(config?: CallableConfig): Partial<CallOptions> {
+    const configCopy: CallableConfig = { ...this.config };
+
+    if (config) {
+      for (const key of Object.keys(config)) {
+        if (key === "metadata") {
+          configCopy[key] = { ...configCopy[key], ...config[key] };
+        } else if (key === "tags") {
+          configCopy[key] = (configCopy[key] ?? []).concat(config[key] ?? []);
+        } else {
+          configCopy[key] = config[key] ?? configCopy[key];
+        }
+      }
+    }
+
+    return configCopy as Partial<CallOptions>;
+  }
+
+  bind(
+    kwargs: Partial<CallOptions>
+  ): CallableBind<CallInput, CallOutput, CallOptions> {
+    return this.constructor({
+      bound: this.bound,
+      kwargs: { ...this.kwargs, ...kwargs },
+      config: this.config,
+    });
+  }
+
+  withConfig(
+    config: CallableConfig
+  ): CallableBind<CallInput, CallOutput, CallOptions> {
+    return this.constructor({
+      bound: this.bound,
+      kwargs: this.kwargs,
+      config: { ...this.config, ...config },
+    });
+  }
+
+  async invoke(
+    input: CallInput,
+    options?: Partial<CallOptions> | undefined
+  ): Promise<CallOutput> {
+    return this.bound.invoke(
+      input,
+      this._mergeConfig({ ...options, ...this.kwargs })
+    );
+  }
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions?: false }
+  ): Promise<CallOutput[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions: true }
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]> {
+    const mergedOptions = Array.isArray(options)
+      ? options.map((option: Partial<CallOptions>) =>
+          this._mergeConfig({ ...option, ...this.kwargs })
+        )
+      : this._mergeConfig({ ...options, ...this.kwargs });
+
+    return this.batch(inputs, mergedOptions, batchOptions);
+  }
+
+  async toInputRecord(
+    aliases: SerializedKeyAlias,
+    secrets: SecretFields,
+    kwargs: SerializedFields
+  ): Promise<Serialized> {
+    return {
+      _grp: 2,
+      _type: "input_record",
+      _id: this._id,
+      _recordId: await this._getRecordId(),
+      _kwargs: mapKeys(
+        Object.keys(secrets).length
+          ? this._removeSecret(kwargs, secrets)
+          : kwargs,
+        keyToJson,
+        aliases
+      ),
+    };
+  }
+
+  async toEventRecord(
+    aliases: SerializedKeyAlias,
+    secrets: SecretFields,
+    kwargs: SerializedFields,
+    outputs: CallOutput,
+    parent?: RecordId | undefined
+  ): Promise<Serialized> {
+    let serializedOutputs: SerializedFields;
+    if (typeof outputs === "object") {
+      serializedOutputs = (outputs ?? {}) as SerializedFields;
+    } else {
+      serializedOutputs = (outputs ? { outputs } : {}) as SerializedFields;
+    }
+
+    const inputKwargs = (await this.toInputRecord(
+      aliases,
+      secrets,
+      kwargs
+    )) as SerializedInputRecord;
+
+    const { _kwargs, ...args } = inputKwargs;
+
+    const currCallableBindArgs = _kwargs as CallableBindArgs<
+      CallInput,
+      CallOutput,
+      CallOptions
+    >;
+
+    const callableBindBound: Serialized =
+      await currCallableBindArgs.bound.toRecord(outputs, parent);
+
+    const callableBindKwargs: Partial<CallOptions> =
+      currCallableBindArgs.kwargs;
+
+    const callableBindConfig: SerializedFields = mapKeyTypes(
+      Object.keys(secrets).length
+        ? this._removeSecret(currCallableBindArgs.config, secrets)
+        : currCallableBindArgs.config,
+      keyToJson,
+      aliases
+    );
+
+    return {
+      _grp: 2,
+      _type: "event_record",
+      _id: this._id,
+      _recordId: await this._getRecordId(),
+      _kwargs: mapKeys(
+        Object.keys(secrets).length
+          ? this._replaceSecret(kwargs, secrets)
+          : kwargs,
+        keyToJson,
+        aliases
+      ),
+      _metadata: {
+        _recordType: RecordType.EVENT,
+        _secrets: await this._getSecretRecord(kwargs, secrets),
+        _inputs: {
+          ...args,
+          _kwargs: {
+            bound: callableBindBound,
+            kwargs: callableBindKwargs,
+            config: callableBindConfig,
+          },
+        },
+        _outputs: (await this.toOutputRecord(
+          aliases,
+          secrets,
+          serializedOutputs
+        )) as SerializedFields,
+        _parent: parent,
+      },
+    };
+  }
+}
+
+export class CallableEach<
+  CallInputItem,
+  CallOutputItem,
+  CallOptions extends CallableConfig,
+> extends Callable<CallInputItem[], CallOutputItem[], CallOptions> {
+  _isCallable = true;
+
+  _isSerializable = true;
+
+  _namespace: string[] = ["record", "callable"];
+
+  bound: Callable<CallInputItem, CallOutputItem, CallOptions>;
+
+  constructor(fields: {
+    bound: Callable<CallInputItem, CallOutputItem, CallOptions>;
+  }) {
+    super(fields);
+    this.bound = fields.bound;
+  }
+
+  bind(kwargs: Partial<CallOptions>) {
+    return new CallableEach({ bound: this.bound.bind(kwargs) });
+  }
+
+  async invoke(
+    inputs: CallInputItem[],
+    options?: Partial<CallOptions>
+  ): Promise<CallOutputItem[]> {
+    return this._callWithConfig(this._invoke, inputs, options);
+  }
+
+  async toRecord(
+    outputs: CallOutputItem[],
+    parent?: RecordId | undefined
+  ): Promise<Serialized> {
+    return super.toRecord(outputs, parent);
+  }
+
+  protected async _invoke(
+    inputs: CallInputItem[],
+    options?: Partial<CallOptions>
+  ): Promise<CallOutputItem[]> {
+    return this.bound.batch(inputs, options);
+  }
+}
+
+export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
+  CallInput,
+  CallOutput
+> {
+  _namespace: string[] = ["record", "callable"];
+
+  _isCallable = true;
+
+  _isSerializable = true;
+
+  static _name(): string {
+    return "CallableWithFallbacks";
+  }
+
+  protected callable: Callable<CallInput, CallOutput>;
+
+  protected fallbacks: Callable<CallInput, CallOutput>[];
+
+  constructor(fields: {
+    callable: Callable<CallInput, CallOutput>;
+    fallbacks: Callable<CallInput, CallOutput>[];
+  }) {
+    super(fields);
+    this.callable = fields.callable;
+    this.fallbacks = fields.fallbacks;
+  }
+
+  *callables() {
+    yield this.callable;
+    for (const callable of this.fallbacks) {
+      yield callable;
+    }
+  }
+
+  async invoke(
+    input: CallInput,
+    options?: Partial<CallableConfig> | undefined
+  ): Promise<CallOutput> {
+    let firstError: Error | undefined;
+
+    for (const callable of this.callables()) {
+      try {
+        const output: CallOutput = await callable.invoke(input, options);
+
+        return output;
+      } catch (e) {
+        if (firstError === undefined) {
+          firstError = e as Error;
+        }
+      }
+    }
+
+    if (firstError === undefined) {
+      throw new Error("Fallbacks end without Error stored.");
+    }
+
+    throw firstError;
+  }
+
+  /**
+   * Batch calls invoke N times, where N is the length of inputs.
+   * Subclasses would override this method with different arguments and returns.
+   * @param inputs Array of inputs in each call in a batch.
+   * @param options Either a single call options to apply to each call or an array of options for each call.
+   * @param batchOptions.maxConcurrency Max number of calls to run at once.
+   * @param batchOptions.returnExceptions Whether to return errors rather than throwing on the first error.
+   * @returns An arrays of CallOutputs, or mixed CallOutputs and Errors (if returnExceptions is true).
+   */
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallableConfig> | Partial<CallableConfig>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions?: false }
+  ): Promise<CallOutput[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallableConfig> | Partial<CallableConfig>[],
+    batchOptions?: CallableBatchOptions & { returnExceptions: true }
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallableConfig> | Partial<CallableConfig>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]>;
+
+  async batch(
+    inputs: CallInput[],
+    options?: Partial<CallableConfig> | Partial<CallableConfig>[],
+    batchOptions?: CallableBatchOptions
+  ): Promise<(CallOutput | Error)[]> {
+    const optionsList: Partial<CallableConfig>[] = this._getOptionsList(
+      options ?? {},
+      inputs.length
+    );
+
+    let firstError: Error | undefined;
+
+    for (const callable of this.callables()) {
+      try {
+        const outputs = await callable.batch(inputs, options, batchOptions);
+
+        return outputs;
+      } catch (e) {
+        if (firstError === undefined) {
+          firstError = e as Error;
+        }
+      }
+    }
+
+    if (firstError === undefined) {
+      throw new Error("Fallbacks end without Error stored.");
+    }
+
+    throw firstError;
+  }
+}

--- a/packages/core/src/record/tests/__snapshots__/callable.test.ts.snap
+++ b/packages/core/src/record/tests/__snapshots__/callable.test.ts.snap
@@ -1,0 +1,354 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test CallableBind 1`] = `
+"_grp: 1
+_type: constructor
+_id:
+  - record
+  - callable
+  - CallableBind
+_kwargs:
+  bound:
+    _grp: 1
+    _type: constructor
+    _id:
+      - tests
+      - Test
+    _kwargs:
+      hello: bind-hello
+      bye: bind-bye
+      serializable_field: true
+      test_api:
+        _grp: 1
+        _type: secret
+        _id:
+          - TEST_API
+  kwargs:
+    _grp: 1
+    _type: constructor
+    _id:
+      - tests
+      - TestBind
+    _kwargs:
+      hello: bind-hello
+      bye: bind-bye
+      serializable_field: true
+      test_api:
+        _grp: 1
+        _type: secret
+        _id:
+          - TEST_API
+  config: {}
+"
+`;
+
+exports[`test CallableBind 2`] = `
+"_grp: 1
+_type: constructor
+_id:
+  - record
+  - callable
+  - CallableBind
+_kwargs:
+  bound:
+    _grp: 1
+    _type: constructor
+    _id:
+      - tests
+      - TestBind
+    _kwargs:
+      hello: bind-hello
+      bye: bind-bye
+      serializable_field: true
+      test_api:
+        _grp: 1
+        _type: secret
+        _id:
+          - TEST_API
+  kwargs:
+    _grp: 1
+    _type: constructor
+    _id:
+      - tests
+      - Test
+    _kwargs:
+      hello: bind-hello
+      bye: bind-bye
+      serializable_field: true
+      test_api:
+        _grp: 1
+        _type: secret
+        _id:
+          - TEST_API
+  config: {}
+"
+`;
+
+exports[`test CallableBind 3`] = `
+{
+  "_grp": 2,
+  "_id": [
+    "record",
+    "callable",
+    "CallableBind",
+  ],
+  "_kwargs": {
+    "bound": {
+      "_grp": 1,
+      "_id": [
+        "tests",
+        "Test",
+      ],
+      "_kwargs": {
+        "bye": "bind-bye",
+        "hello": "bind-hello",
+        "serializable_field": true,
+        "test_api": {
+          "_grp": 1,
+          "_id": [
+            "TEST_API",
+          ],
+          "_type": "secret",
+        },
+      },
+      "_type": "constructor",
+    },
+    "config": {},
+    "kwargs": {
+      "_grp": 1,
+      "_id": [
+        "tests",
+        "TestBind",
+      ],
+      "_kwargs": {
+        "bye": "bind-bye",
+        "hello": "bind-hello",
+        "serializable_field": true,
+        "test_api": {
+          "_grp": 1,
+          "_id": [
+            "TEST_API",
+          ],
+          "_type": "secret",
+        },
+      },
+      "_type": "constructor",
+    },
+  },
+  "_metadata": {
+    "_inputs": {
+      "_grp": 2,
+      "_id": [
+        "record",
+        "callable",
+        "CallableBind",
+      ],
+      "_kwargs": {
+        "bound": {
+          "_grp": 2,
+          "_id": [
+            "tests",
+            "Test",
+          ],
+          "_kwargs": {
+            "bye": "bind-bye",
+            "hello": "bind-hello",
+            "serializable_field": true,
+            "test_api": {
+              "_grp": 1,
+              "_id": [
+                "TEST_API",
+              ],
+              "_type": "secret",
+            },
+          },
+          "_metadata": {
+            "_inputs": {
+              "_grp": 2,
+              "_id": [
+                "tests",
+                "Test",
+              ],
+              "_kwargs": {
+                "bye": "string",
+                "hello": "string",
+                "serializable_field": "boolean",
+              },
+              "_recordId": Any<String>,
+              "_type": "input_record",
+            },
+            "_outputs": {
+              "_grp": 2,
+              "_id": [
+                "tests",
+                "Test",
+              ],
+              "_kwargs": {
+                "outputs": "string",
+              },
+              "_recordId": Any<String>,
+              "_type": "output_record",
+            },
+            "_recordType": "event",
+            "_secrets": {
+              "_grp": 2,
+              "_id": [
+                "TEST_API",
+              ],
+              "_recordId": Any<String>,
+              "_type": "secret_record",
+            },
+          },
+          "_recordId": Any<String>,
+          "_type": "event_record",
+        },
+        "config": {},
+        "kwargs": {
+          "_grp": 1,
+          "_id": [
+            "tests",
+            "TestBind",
+          ],
+          "_kwargs": {
+            "bye": "bind-bye",
+            "hello": "bind-hello",
+            "serializable_field": true,
+            "test_api": {
+              "_grp": 1,
+              "_id": [
+                "TEST_API",
+              ],
+              "_type": "secret",
+            },
+          },
+          "_type": "constructor",
+        },
+      },
+      "_recordId": Any<String>,
+      "_type": "input_record",
+    },
+    "_outputs": {
+      "_grp": 2,
+      "_id": [
+        "record",
+        "callable",
+        "CallableBind",
+      ],
+      "_kwargs": {
+        "outputs": "string",
+      },
+      "_recordId": Any<String>,
+      "_type": "output_record",
+    },
+    "_recordType": "event",
+    "_secrets": {},
+  },
+  "_recordId": Any<String>,
+  "_type": "event_record",
+}
+`;
+
+exports[`test CallableEach 1`] = `
+"_grp: 1
+_type: constructor
+_id:
+  - record
+  - callable
+  - CallableEach
+_kwargs:
+  bound:
+    _grp: 1
+    _type: constructor
+    _id:
+      - tests
+      - Test
+    _kwargs:
+      hello: hello
+      bye: bye
+      serializable_field: true
+      test_api:
+        _grp: 1
+        _type: secret
+        _id:
+          - TEST_API
+"
+`;
+
+exports[`test custom callable 1`] = `
+"_grp: 1
+_type: constructor
+_id:
+  - tests
+  - Test
+_kwargs:
+  hello: hello
+  bye: bye
+  serializable_field: true
+  test_api:
+    _grp: 1
+    _type: secret
+    _id:
+      - TEST_API
+"
+`;
+
+exports[`test custom callable 2`] = `
+{
+  "_grp": 2,
+  "_id": [
+    "tests",
+    "Test",
+  ],
+  "_kwargs": {
+    "bye": "bye",
+    "hello": "hello",
+    "serializable_field": true,
+    "test_api": {
+      "_grp": 1,
+      "_id": [
+        "TEST_API",
+      ],
+      "_type": "secret",
+    },
+  },
+  "_metadata": {
+    "_inputs": {
+      "_grp": 2,
+      "_id": [
+        "tests",
+        "Test",
+      ],
+      "_kwargs": {
+        "bye": "string",
+        "hello": "string",
+        "serializable_field": "boolean",
+      },
+      "_recordId": Any<String>,
+      "_type": "input_record",
+    },
+    "_outputs": {
+      "_grp": 2,
+      "_id": [
+        "tests",
+        "Test",
+      ],
+      "_kwargs": {
+        "outputs": "string",
+      },
+      "_recordId": Any<String>,
+      "_type": "output_record",
+    },
+    "_recordType": "event",
+    "_secrets": {
+      "_grp": 2,
+      "_id": [
+        "TEST_API",
+      ],
+      "_recordId": Any<String>,
+      "_type": "secret_record",
+    },
+  },
+  "_recordId": Any<String>,
+  "_type": "event_record",
+}
+`;

--- a/packages/core/src/record/tests/callable.test.ts
+++ b/packages/core/src/record/tests/callable.test.ts
@@ -1,0 +1,409 @@
+import { expect, test } from "@jest/globals";
+import { stringify } from "yaml";
+import { load } from "../../load";
+import { OptionalImportMap, SecretMap } from "../../load/importType.js";
+import { SecretFields } from "../../load/keymap";
+import { SerializedConstructor } from "../../load/serializable";
+import {
+  Callable,
+  CallableConfigFields,
+  CallableConfig,
+  CallableBindArgs,
+} from "../callable";
+
+test("test custom callable", async () => {
+  type TestInput = {
+    input: string | boolean;
+  };
+
+  interface TestParams extends CallableConfig {
+    hello: string;
+    bye: string;
+    testApi: string;
+  }
+
+  interface SerializableTestParams extends TestParams {
+    serializableField: boolean;
+  }
+
+  class Test<
+      CallOptions extends SerializableTestParams = SerializableTestParams,
+    >
+    extends Callable<TestInput, string, CallOptions>
+    implements TestParams
+  {
+    _namespace: string[] = ["tests"];
+
+    _isCallable = true;
+
+    _isSerializable = true;
+
+    get _secrets(): SecretFields | undefined {
+      return {
+        testApi: "TEST_API",
+      };
+    }
+
+    get _aliases(): SecretFields | undefined {
+      return {
+        testApi: "test_api",
+      };
+    }
+
+    hello: string;
+
+    bye: string;
+
+    testApi: string;
+
+    constructor(fields?: Partial<TestInput> & SerializableTestParams) {
+      super(fields ?? {});
+      this.hello = fields?.hello ?? "default-hello";
+      this.bye = fields?.bye ?? "default-bye";
+      this.testApi = fields?.testApi ?? "default-api";
+    }
+
+    async invoke(
+      input: TestInput,
+      options?: Partial<CallOptions> | undefined
+    ): Promise<string> {
+      this.hello = options?.hello ?? this.hello;
+      this.bye = options?.bye ?? this.bye;
+
+      return `${this.hello}-${String(input.input)}-${this.bye}-${String(
+        this._kwargs.serializableField
+      )}`;
+    }
+  }
+
+  const test = new Test({
+    hello: "hello",
+    bye: "bye",
+    serializableField: true,
+    testApi: "this-is-api",
+  });
+  const argumentsBefore = test._kwargs;
+  const serializedStr: string = JSON.stringify(test, null, 2);
+
+  expect(test._kwargs).toEqual(argumentsBefore);
+  expect(stringify(JSON.parse(serializedStr))).toMatchSnapshot();
+
+  expect(await test.invoke({ input: "input" })).toBe("hello-input-bye-true");
+  expect(await test.invoke({ input: true })).toBe("hello-true-bye-true");
+
+  const test2 = await load<Test>(
+    serializedStr,
+    { TEST_API: "this-is-a-key" } as SecretMap,
+    { tests: { Test } } as OptionalImportMap
+  );
+
+  expect(test2).toBeInstanceOf(Test);
+  expect(JSON.stringify(test2, null, 2)).toBe(serializedStr);
+
+  expect(await test2.invoke({ input: "input" })).toBe("hello-input-bye-true");
+  expect(await test2.invoke({ input: true })).toBe("hello-true-bye-true");
+
+  expect(
+    await test2.invoke(
+      { input: "input" },
+      { hello: "new-hello", bye: "new-bye" }
+    )
+  ).toBe("new-hello-input-new-bye-true");
+  expect(
+    await test2.invoke({ input: true }, { hello: "new-hello", bye: "new-bye" })
+  ).toBe("new-hello-true-new-bye-true");
+
+  const record = await test.toRecord("output");
+  const recordStr = JSON.stringify(record, null, 2);
+  expect(JSON.parse(recordStr)).toMatchSnapshot({
+    _recordId: expect.any(String),
+    _metadata: {
+      _secrets: {
+        _recordId: expect.any(String),
+      },
+      _inputs: {
+        _recordId: expect.any(String),
+      },
+      _outputs: {
+        _recordId: expect.any(String),
+      },
+    },
+  });
+
+  const test3 = await load<Test>(
+    recordStr,
+    { TEST_API: "this-is-a-key" } as SecretMap,
+    { tests: { Test } } as OptionalImportMap
+  );
+
+  expect(test3).toBeInstanceOf(Test);
+  expect(JSON.stringify(test3, null, 2)).toBe(serializedStr);
+});
+
+test("test CallableBind", async () => {
+  type TestInput = {
+    input: string | boolean;
+  };
+
+  interface TestParams extends CallableConfig {
+    hello: string;
+    bye: string;
+    testApi: string;
+  }
+
+  interface SerializableTestParams extends TestParams {
+    serializableField: boolean;
+  }
+
+  class Test<
+      CallOptions extends SerializableTestParams = SerializableTestParams,
+    >
+    extends Callable<TestInput, string, CallOptions>
+    implements TestParams
+  {
+    _namespace: string[] = ["tests"];
+
+    _isCallable = true;
+
+    _isSerializable = true;
+
+    get _secrets(): SecretFields | undefined {
+      return {
+        testApi: "TEST_API",
+      };
+    }
+
+    get _aliases(): SecretFields | undefined {
+      return {
+        testApi: "test_api",
+      };
+    }
+
+    hello: string;
+
+    bye: string;
+
+    testApi: string;
+
+    constructor(fields?: Partial<TestInput> & SerializableTestParams) {
+      super(fields ?? {});
+      this.hello = fields?.hello ?? "default-hello";
+      this.bye = fields?.bye ?? "default-bye";
+      this.testApi = fields?.testApi ?? "default-api";
+    }
+
+    async invoke(
+      input: TestInput,
+      options?: Partial<CallOptions> | undefined
+    ): Promise<string> {
+      this.hello = options?.hello ?? this.hello;
+      this.bye = options?.bye ?? this.bye;
+
+      return `${this.hello}-${String(input.input)}-${this.bye}-${String(
+        this._kwargs.serializableField
+      )}`;
+    }
+  }
+
+  class TestBind<
+      CallOptions extends SerializableTestParams = SerializableTestParams,
+    >
+    extends Callable<TestInput, string, CallOptions>
+    implements TestParams
+  {
+    _namespace: string[] = ["tests"];
+
+    _isCallable = true;
+
+    _isSerializable = true;
+
+    get _secrets(): SecretFields | undefined {
+      return {
+        testApi: "TEST_API",
+      };
+    }
+
+    get _aliases(): SecretFields | undefined {
+      return {
+        testApi: "test_api",
+      };
+    }
+
+    hello: string;
+
+    bye: string;
+
+    testApi: string;
+
+    constructor(fields?: Partial<TestInput> & SerializableTestParams) {
+      super(fields ?? {});
+      this.hello = fields?.hello ?? "default-hello";
+      this.bye = fields?.bye ?? "default-bye";
+      this.testApi = fields?.testApi ?? "default-api";
+    }
+
+    async invoke(
+      input: TestInput,
+      options?: Partial<CallOptions> | undefined
+    ): Promise<string> {
+      return "this-is-a-bind";
+    }
+  }
+
+  const test = new Test({
+    hello: "hello",
+    bye: "bye",
+    serializableField: true,
+    testApi: "this-is-api",
+  });
+
+  const testbind = new TestBind({
+    hello: "bind-hello",
+    bye: "bind-bye",
+    serializableField: true,
+    testApi: "bind-this-is-api",
+  });
+
+  const tBind = testbind.bind(test);
+  const newTest = test.bind(testbind);
+
+  expect(await tBind.invoke({ input: "input" })).toBe("this-is-a-bind");
+  expect(await newTest.invoke({ input: "input" })).toBe(
+    "bind-hello-input-bind-bye-true"
+  );
+
+  const serializedStr: string = JSON.stringify(newTest, null, 2);
+  expect(stringify(JSON.parse(serializedStr))).toMatchSnapshot();
+
+  expect(
+    stringify(JSON.parse(JSON.stringify(tBind, null, 2)))
+  ).toMatchSnapshot();
+
+  const record = await newTest.toRecord("output");
+  const recordStr = JSON.stringify(record, null, 2);
+  expect(JSON.parse(recordStr)).toMatchSnapshot({
+    _recordId: expect.any(String),
+    _metadata: {
+      _inputs: {
+        _recordId: expect.any(String),
+        _kwargs: {
+          bound: {
+            _recordId: expect.any(String),
+            _metadata: {
+              _secrets: {
+                _recordId: expect.any(String),
+              },
+              _inputs: {
+                _recordId: expect.any(String),
+              },
+              _outputs: {
+                _recordId: expect.any(String),
+              },
+            },
+          },
+        },
+      },
+      _outputs: {
+        _recordId: expect.any(String),
+      },
+    },
+  });
+
+  const newBindObj = JSON.parse(serializedStr) as SerializedConstructor;
+  const newBindArgs = newBindObj._kwargs as CallableBindArgs<
+    TestInput,
+    string,
+    SerializableTestParams
+  >;
+
+  const newTest2 = await load<Test>(
+    JSON.stringify(newBindArgs.bound, null, 2),
+    { TEST_API: 'this-is-a-key' } as SecretMap,
+    { tests: { Test } } as OptionalImportMap
+  );
+  expect(newTest2).toBeInstanceOf(Test);
+
+  const newTest3 = await load<TestBind>(
+    JSON.stringify(newBindArgs.kwargs, null, 2),
+    { TEST_API: 'this-is-a-key' } as SecretMap,
+    { tests: { TestBind } } as OptionalImportMap
+  );
+  expect(newTest3).toBeInstanceOf(TestBind);
+});
+
+test("test CallableEach", async () => {
+  type TestInput = {
+    input: string | boolean;
+  };
+
+  interface TestParams extends CallableConfig {
+    hello: string;
+    bye: string;
+    testApi: string;
+  }
+
+  interface SerializableTestParams extends TestParams {
+    serializableField: boolean;
+  }
+
+  class Test<
+      CallOptions extends SerializableTestParams = SerializableTestParams,
+    >
+    extends Callable<TestInput, string, CallOptions>
+    implements TestParams
+  {
+    _namespace: string[] = ["tests"];
+
+    _isCallable = true;
+
+    _isSerializable = true;
+
+    get _secrets(): SecretFields | undefined {
+      return {
+        testApi: "TEST_API",
+      };
+    }
+
+    get _aliases(): SecretFields | undefined {
+      return {
+        testApi: "test_api",
+      };
+    }
+
+    hello: string;
+
+    bye: string;
+
+    testApi: string;
+
+    constructor(fields?: Partial<TestInput> & SerializableTestParams) {
+      super(fields ?? {});
+      this.hello = fields?.hello ?? "default-hello";
+      this.bye = fields?.bye ?? "default-bye";
+      this.testApi = fields?.testApi ?? "default-api";
+    }
+
+    async invoke(
+      input: TestInput,
+      options?: Partial<CallOptions> | undefined
+    ): Promise<string> {
+      this.hello = options?.hello ?? this.hello;
+      this.bye = options?.bye ?? this.bye;
+
+      return `${this.hello}-${String(input.input)}-${this.bye}-${String(
+        this._kwargs.serializableField
+      )}`;
+    }
+  }
+
+  const test = new Test({
+    hello: "hello",
+    bye: "bye",
+    serializableField: true,
+    testApi: "this-is-api",
+  });
+
+  const testMap = test.map();
+  const serializedStr: string = JSON.stringify(testMap, null, 2);
+  expect(stringify(JSON.parse(serializedStr))).toMatchSnapshot();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,6 +2602,40 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.5.11":
+  version "1.5.11"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.5.11.tgz#5ee8620fea56c67cb427228c35d8403518efe622"
+  integrity sha512-cV7yHcOAtNQ5x/yQl7Yw1xf53kO0FNDTdDU6bFIMbW6ljB7U7ns0YRM+QIkpoqTAt6zK5k9Fq0QWlUbLcq9AvA==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.0.tgz#cc2b82e5141a29ada2cce7d267a6b74baa6dd519"
+  integrity sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==
+
+"@redis/json@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.6.tgz#b7a7725bbb907765d84c99d55eac3fcf772e180e"
+  integrity sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==
+
+"@redis/search@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.1.5.tgz#682b68114049ff28fdf2d82c580044dfb74199fe"
+  integrity sha512-hPP8w7GfGsbtYEJdn4n7nXa6xt6hVZnnDktKW4ArMaFQ/m/aR7eFvsLQmG/mn1Upq99btPJk+F27IQ2dYpCoUg==
+
+"@redis/time-series@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.5.tgz#a6d70ef7a0e71e083ea09b967df0a0ed742bc6ad"
+  integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -3311,6 +3345,11 @@
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz#9b0e3e8533fe5024ad32d6637eb9589988b6fdca"
   integrity sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==
+
+"@types/object-hash@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-3.0.5.tgz#f028398f9d918a4dcb57c50d16fc15023db6b244"
+  integrity sha512-WFGeSazfL5BWbEh5ACaAIs5RT6sbVIwBs1rgHUp+kZzX/gub41LEEYWTWbYnE/sKb7hDdPEsGa1Vmcaay2fS5g==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -4783,6 +4822,11 @@ clsx@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
+
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -6835,6 +6879,11 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -10840,6 +10889,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis@^4.6.10:
+  version "4.6.10"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.10.tgz#07f6ea2b2c5455b098e76d1e8c9b3376114e9458"
+  integrity sha512-mmbyhuKgDiJ5TWUhiKhBssz+mjsuSI/lSZNPI9QvZOYzWvYGejtb+W3RlDDf8LD6Bdl5/mZeG8O1feUGhXTxEg==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.5.11"
+    "@redis/graph" "1.1.0"
+    "@redis/json" "1.0.6"
+    "@redis/search" "1.1.5"
+    "@redis/time-series" "1.0.5"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -11985,6 +12046,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiktoken@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/tiktoken/-/tiktoken-1.0.10.tgz#d5ade07bc19f4424c404646b606e64674b0df5ef"
+  integrity sha512-gF8ndTCNu7WcRFbl1UUWaFIB4CTXmHzS3tRYdyUYF7x3C6YR6Evoao4zhKDmWIwv2PzNbzoQMV8Pxt+17lEDbA==
+
 tiny-invariant@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
@@ -12999,15 +13065,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"


### PR DESCRIPTION
Design Callable modules for executing events in encre-core. 

A Callable module should include input fields, output fields, and other executing options. For example, a dummy Callable can be designed in the below code snippet:
```typescript
type TestInput = {
  input: string | boolean;
};

interface TestParams extends CallableConfig {
  testApi: string;
}

class Test<CallOptions extends TestParams = TestParams>
  extends Callable<TestInput, string, CallOptions>
  implements TestParams
{
  _namespace: string[] = ["tests"];

  _isCallable = true;

  _isSerializable = true;

  get _secrets(): SecretFields | undefined {
    return {
      testApi: "TEST_API",
    };
  }

  get _aliases(): SecretFields | undefined {
    return {
      testApi: "test_api",
    };
  }

  testApi: string;

  constructor(fields?: Partial<TestInput> & TestParams) {
    super(fields ?? {});
    this.testApi = fields?.testApi ?? "default-api";
  }

  async invoke(
    input: TestInput,
    options?: Partial<CallOptions> | undefined
  ): Promise<string> {
    // your event logic happens here
    return 'output result';
  }
}
```

In the above example, the input field of the Callable `Test` is `TestInput`, the output field is `string`, and there is a secret key `testApi` stored as the parameters in the Callable `Test`.

Functions in `Test` are:
* `invoke(inputs: CallInput, options: Partial<CallOptions>)`: take `TestInput` as inputs (if there are any updates on the fields in `TestParams`, for example, a new secret key `testAPI`, then can use `options` to update the corresponding field), perform event logics and return `string` as outputs.
* `map()`: return a new `CallableEach` class, which extends the `Callable` with `TestInput[]` as inputs and `string[]` as outputs. (Note: the `CallableEach` class can take multiple inputs as a batch and then return multiple outputs).
* `bind(kwargs: Partial<CallOptions>)`: return a new `CallableBind` class, which extends the `Callable` with addtional information about the binding:
  * `bound`: `Callable` of the class `Test`.
  * `config`: binding configurations such as 
    * `name`: Name of the Callable class.
    * `tags`: Tags for this call and any sub-calls.
    * `metadata`: Metadata for this call and any sub-calls.
    * `callbacks`: Callbacks for this calls and any sub-calls. (NOT implemented yet)
  * `kwargs`: Additional updates on the fields in `TestParams`.