### PR TITLE
Encre-core: clean functionalities in BaseLM and BaseLLM

### DIFF
--- a/packages/core/src/events/inference/chat/llms/base.ts
+++ b/packages/core/src/events/inference/chat/llms/base.ts
@@ -1,27 +1,22 @@
-import { TiktokenModel, type Tiktoken } from 'js-tiktoken/lite';
+import { TiktokenModel } from 'js-tiktoken/lite';
 import { BaseCache } from '../../../../cache/base.js';
 import { MemoryCache } from '../../../../cache/index.js';
 import {
-  Callable,
-  CallableConfigFields,
   type CallableConfig,
 } from '../../../../record/callable.js';
 import {
-  AsyncCallError,
   AsyncCaller,
   type AsyncCallerParams,
 } from '../../../../utils/asyncCaller.js';
 import {
   encodingForModel,
+  getNumTokens,
   getTiktokenModel,
 } from '../../../../utils/tokenizer.js';
-import { BaseEventParams } from '../../../base.js';
+import { BaseEvent, BaseEventParams } from '../../../base.js';
 import {
-  type BaseMessage,
   type BaseMessageLike,
   convertMessageLikeToMessage,
-  getChatString,
-  BotMessage,
 } from '../../../input/load/msgs/base.js';
 import { BasePrompt, StringPrompt } from '../../../input/load/prompts/base.js';
 import { ChatPrompt } from '../../../input/load/prompts/chat.js';
@@ -65,7 +60,7 @@ export abstract class BaseLM<
     CallOutput = unknown,
     CallOptions extends BaseLMCallOptions = BaseLMCallOptions,
   >
-  extends Callable<BaseLMInput, CallOutput, CallOptions>
+  extends BaseEvent<BaseLMInput, CallOutput, CallOptions>
   implements BaseLMParams
 {
   /**
@@ -82,11 +77,6 @@ export abstract class BaseLM<
    * Cache instance to store and retrieve results for given prompts.
    */
   cache?: BaseCache;
-
-  /**
-   * Instance of Tiktoken to calculate the number of tokens in a given string.
-   */
-  private _encoding?: Tiktoken;
 
   /**
    * Constructor for the BaseLM class.
@@ -119,87 +109,37 @@ export abstract class BaseLM<
   abstract _modelType(): string;
 
   /**
-   * Abstract method to provides the core logic to interface with the language model,
+   * Abstract method to invoke the language model with a given input and options.
+   * @param input - The input for the language model.
+   * @param options - Optional call options.
+   * @returns {Promise<LLMResult>} The output llm result from the language model.
+   */
+  abstract invoke(input: BaseLMInput, options?: Partial<CallOptions>): Promise<CallOutput>;
+
+  /**
+   * Abstract method to provide the core logic to interface with the language model,
    * handling both cached and uncached predictions.
-   * @param {string[]} prompts - An array of prompts.
+   * @param {string} prompt - A prompt.
    * @param {string[] | CallOptions} [options] - Optional call options or an array of stop words.
    * @param {any} [callbacks] - Optional callbacks.
    * @returns {Promise<LLMResult>} The result from the language model.
    */
   abstract provide(
-    prompts: string[],
+    prompt: string,
     options?: string[] | CallOptions,
     callbacks?: any
   ): Promise<LLMResult>;
-
-  /**
-   * Abstract method to provide language model result with prompts {@link BasePrompt[]}.
-   * @param {BasePrompt[]} prompts - Array of prompts.
-   * @param {string[] | CallOptions} [options] - Optional call options or an array of stop words.
-   * @param {any} [callbacks] - Optional callbacks.
-   * @returns {Promise<LLMResult>} The result from the language model.
-   */
-  abstract provideWithPrompts(
-    prompts: BasePrompt[],
-    options?: string[] | CallOptions,
-    callbacks?: any
-  ): Promise<LLMResult>;
-
-  /**
-   * Abstract method to predict output based on a given text.
-   * @param {string} text - The input text.
-   * @param {string[] | CallOptions} [options] - Optional call options or an array of stop words.
-   * @param {any} [callbacks] - Optional callbacks.
-   * @returns {Promise<string>} The predicted output.
-   */
-  abstract predict(
-    text: string,
-    options?: string[] | CallOptions,
-    callbacks?: any
-  ): Promise<string>;
-
-  /**
-   * Abstract method to generate a prediction based on a set of messages.
-   * @param {BaseMessage[]} messages - Array of messages.
-   * @param {string[] | CallOptions} [options] - Optional call options or an array of stop words.
-   * @param {any} [callbacks] - Optional callbacks.
-   * @returns {Promise<BaseMessage>} The bot's message after prediction.
-   */
-  abstract predictWithMessages(
-    messages: BaseMessage[],
-    options?: string[] | CallOptions,
-    callbacks?: any
-  ): Promise<BaseMessage>;
 
   /**
    * Calculates the number of tokens in the given text.
    * @param {string} text - The input text.
    * @returns {Promise<number>} The number of tokens in the input text.
    */
-  async getNumTokens(text: string) {
-    // fallback for calulating text's tokens
-    // 1 token ~= 4 chars in English
-    let numTokens: number = Math.ceil(text.length / 4);
-
-    if (!this._encoding) {
-      try {
-        this._encoding = await encodingForModel(
-          'modelName' in this
-            ? getTiktokenModel(this.modelName as string)
-            : 'gpt2'
-        );
-      } catch (e) {
-        console.warn(
-          `Failed to calculate correct number of tokens, now we use 1 token ~= 4 chars in English for approximate token calculation: ${e}`
-        );
-      }
-    }
-
-    if (this._encoding) {
-      numTokens = this._encoding.encode(text).length;
-    }
-
-    return numTokens;
+  async getNumTokens(text: string): Promise<number> {
+    return getNumTokens(
+      text,
+      'modelName' in this ? getTiktokenModel(this.modelName as string) : 'gpt2'
+    );
   }
 
   /**
@@ -265,7 +205,7 @@ export interface BaseLLMParams extends BaseLMParams {}
  */
 export abstract class BaseLLM<
   CallOptions extends BaseLLMCallOptions = BaseLLMCallOptions,
-> extends BaseLM<string, CallOptions> {
+> extends BaseLM<LLMResult, CallOptions> {
   /**
    * Represents the type for call options without some specified properties.
    */
@@ -299,81 +239,33 @@ export abstract class BaseLLM<
    * Invokes the language model with a given input and options.
    * @param input - The input for the language model.
    * @param options - Optional call options.
-   * @returns {Promise<string>} The output from the language model.
+   * @returns {Promise<LLMResult>} The output llm result from the language model.
    */
-  async invoke(input: BaseLMInput, options?: CallOptions): Promise<string> {
+  async invoke(input: BaseLMInput, options?: CallOptions): Promise<LLMResult> {
     const prompt: BasePrompt = BaseLLM._convertInputToPrompt(input);
-    const result: LLMResult = await this.provideWithPrompts(
-      [prompt],
+    const result: LLMResult = await this.provide(
+      prompt.toString(),
       options,
       options?.callbacks
     );
 
-    return result.generations[0][0].output as string;
-  }
-
-  /**
-   * Calls the language model with a given prompt and options.
-   * @param prompt - The prompt for the language model.
-   * @param options - Optional call options or an array of stop words.
-   * @param callbacks - Optional callbacks.
-   * @returns {Promise<string>} The output from the language model.
-   */
-  async call(
-    prompt: string,
-    options?: CallOptions | string[],
-    callbacks?: any
-  ): Promise<string> {
-    const { generations } = await this.provide([prompt], options, callbacks);
-    return generations[0][0].output as string;
-  }
-
-  /**
-   * Predicts the output based on a given text.
-   * @param text - The input text.
-   * @param options - Optional call options or an array of stop words.
-   * @param callbacks - Optional callbacks.
-   * @returns {Promise<string>} The predicted output.
-   */
-  async predict(
-    text: string,
-    options?: CallOptions | string[],
-    callbacks?: any
-  ): Promise<string> {
-    return this.call(text, options, callbacks);
-  }
-
-  /**
-   * Generates a prediction based on a set of messages.
-   * @param messages - An array of messages.
-   * @param options - Optional call options or an array of stop words.
-   * @param callbacks - Optional callbacks.
-   * @returns {Promise<BaseMessage>} The bot's message after prediction.
-   */
-  async predictWithMessages(
-    messages: BaseMessage[],
-    options?: CallOptions | string[],
-    callbacks?: any
-  ): Promise<BaseMessage> {
-    const text: string = getChatString(messages);
-    const prediction: string = await this.call(text, options, callbacks);
-    return new BotMessage(prediction);
+    return result;
   }
 
   /**
    * Provides the core logic to interface with the language model, handling both cached and uncached predictions.
-   * @param prompts - An array of prompts.
+   * @param {string} prompt - A prompt.
    * @param options - Optional call options or an array of stop words.
    * @param callbacks - Optional callbacks.
    * @returns {Promise<LLMResult>} The result from the language model.
    */
   async provide(
-    prompts: string[],
+    prompt: string,
     options?: CallOptions | string[],
     callbacks?: any
   ): Promise<LLMResult> {
-    if (!Array.isArray(prompts)) {
-      throw new Error("Argument 'prompts' must be string[]");
+    if (Array.isArray(prompt) || !(typeof prompt === 'string')) {
+      throw new Error("Argument 'prompt' must be string");
     }
 
     let parsedOptions: CallOptions | undefined;
@@ -389,91 +281,46 @@ export abstract class BaseLLM<
 
     const llmStrKey: string = this._getLLMStrKey(serializedCallOptions);
 
-    const uncachedPromptIndices: number[] = [];
-    const generations: (Generation[] | null | undefined)[] = await Promise.all(
-      prompts.map(async (prompt, idx) => {
-        const result: Generation[] | null | undefined =
-          await this.cache?.lookup([prompt, llmStrKey]);
-
-        if (result === null || result === undefined) {
-          uncachedPromptIndices.push(idx);
-        }
-
-        return result;
-      })
-    );
+    let generations: Generation[] | null | undefined = await this.cache?.lookup([prompt, llmStrKey]);
 
     let llmOutput = {};
-    if (uncachedPromptIndices.length > 0) {
-      const llmResult: LLMResult = await this._provideUncached(
-        uncachedPromptIndices.map((i: number) => prompts[i]),
-        serializedCallOptions
-      );
+    if (generations === null || generations === undefined) {
+      const llmResult: LLMResult = await this._provideUncached(prompt, serializedCallOptions);
+      await this.cache?.update([prompt, llmStrKey], llmResult.generations);
 
-      await Promise.all(
-        llmResult.generations.map(
-          async (generation: Generation[], idx: number) => {
-            const uncachedPromptIdx: number = uncachedPromptIndices[idx];
-            generations[uncachedPromptIdx] = generation;
-            return this.cache?.update(
-              [prompts[uncachedPromptIdx], llmStrKey],
-              generation
-            );
-          }
-        )
-      );
-
+      generations = llmResult.generations;
       llmOutput = llmResult.llmOutput ?? {};
     }
 
-    return { generations: generations as Generation[][], llmOutput };
-  }
-
-  /**
-   * Method to provide language model result with prompts {@link BasePrompt[]}.
-   * Transforms prompts to strings and delegates the call to the `provide` method.
-   * @param prompts - An array of prompts.
-   * @param options - Optional call options or an array of stop words.
-   * @param callbacks - Optional callbacks.
-   * @returns {Promise<LLMResult>} The result from the language model.
-   */
-  async provideWithPrompts(
-    prompts: BasePrompt[],
-    options?: string[] | CallOptions,
-    callbacks?: any
-  ): Promise<LLMResult> {
-    const promptStrs: string[] = prompts.map((prompt: BasePrompt) =>
-      prompt.toString()
-    );
-    return this.provide(promptStrs, options, callbacks);
+    return { generations, llmOutput };
   }
 
   /**
    * Abstract method that interfaces with the underlying language model. Must be implemented by subclasses.
-   * @param prompts - An array of prompts.
+   * @param {string} prompt - A prompt.
    * @param options - Call options.
    * @returns {Promise<LLMResult>} The result from the language model.
    */
   abstract _provide(
-    prompts: string[],
+    prompt: string,
     options: this['SerializedCallOptions']
   ): Promise<LLMResult>;
 
   /**
    * Handles uncached prompts and calls the `_provide` method.
-   * @param prompts - An array of prompts.
+   * @param {string} prompt - A prompt.
    * @param serializedCallOptions - Serialized call options.
    * @returns {Promise<LLMResult>} The result from the language model.
    */
   protected async _provideUncached(
-    prompts: string[],
+    prompt: string,
     serializedCallOptions: this['SerializedCallOptions']
   ): Promise<LLMResult> {
     let output: LLMResult;
 
     /*eslint no-useless-catch: "warn"*/
     try {
-      output = await this._provide(prompts, serializedCallOptions);
+      output = await this._provide(prompt, serializedCallOptions);
     } catch (e) {
       throw e;
     }

--- a/packages/core/src/events/inference/chat/llms/openai/index.ts
+++ b/packages/core/src/events/inference/chat/llms/openai/index.ts
@@ -2,7 +2,6 @@ import {
   APIConnectionTimeoutError,
   APIUserAbortError,
   OpenAI as OpenAIClient,
-  ClientOptions as OpenAIClientOptions,
 } from 'openai';
 import type { RequestOptions as OpenAIClientRequestOptions } from 'openai/core';
 
@@ -149,9 +148,6 @@ export interface OpenAIBaseInput {
 }
 
 export interface OpenAIInput extends OpenAIBaseInput {
-  /** Batch size to use when passing multiple documents to generate */
-  batchSize: number;
-
   /**
    * Generates `bestOf` completions server-side and returns the "best" (the one with
    * the highest log probability per token). Results cannot be streamed.

--- a/packages/core/src/events/inference/chat/llms/tests/__snapshots__/base.test.ts.snap
+++ b/packages/core/src/events/inference/chat/llms/tests/__snapshots__/base.test.ts.snap
@@ -13,109 +13,66 @@ _id:
 `;
 
 exports[`test BaseLLM 2`] = `
-"{
-  "_grp": 1,
-  "_type": "constructor",
-  "_id": [
-    "input",
-    "load",
-    "msgs",
-    "BotMessage"
-  ],
-  "_kwargs": {
-    "content": "System: this is a system message\\nHuman: this is a human message"
-  }
-}"
+"generations:
+  - output: this is a prompt.
+    info:
+      index: 0
+llmOutput: {}
+"
 `;
 
 exports[`test BaseLLM 3`] = `
-"{
-  "generations": [
-    [
-      {
-        "output": "System: this is a system message",
-        "info": {
-          "index": 0
-        }
-      },
-      {
-        "output": "Human: this is a human message",
-        "info": {
-          "index": 1
-        }
-      }
-    ],
-    [
-      {
-        "output": "AI: this is a bot message",
-        "info": {
-          "index": 0
-        }
-      }
-    ],
-    null
-  ],
-  "llmOutput": {}
-}"
+"generations:
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+      AI: this is a bot message
+    info:
+      index: 0
+llmOutput: {}
+"
 `;
 
 exports[`test BaseLLM 4`] = `
-"{
-  "generations": [
-    [
-      {
-        "output": "this is a prompt.",
-        "info": {
-          "index": 0
-        }
-      }
-    ],
-    [
-      {
-        "output": "System: this is a system message\\nHuman: this is a human message",
-        "info": {
-          "index": 0
-        }
-      }
-    ],
-    [
-      {
-        "output": "this is a prompt.",
-        "info": {
-          "index": 0
-        }
-      }
-    ]
-  ],
-  "llmOutput": {}
-}"
+"generations:
+  - output: |-
+      Human: this is a human message 1
+      Human: this is a human message 2
+      Human: this is a human message 3
+    info:
+      index: 0
+llmOutput: {}
+"
 `;
 
 exports[`test BaseLLM 5`] = `
-"this is a prompt.
+"generations:
+  - output: this is a prompt.
+    info:
+      index: 0
+llmOutput: {}
 "
 `;
 
 exports[`test BaseLLM 6`] = `
-"|-
-System: this is a system message
-Human: this is a human message
-AI: this is a bot message
+"generations:
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+    info:
+      index: 0
+llmOutput: {}
 "
 `;
 
 exports[`test BaseLLM 7`] = `
-"|-
-Human: this is a human message 1
-Human: this is a human message 2
-Human: this is a human message 3
-"
-`;
-
-exports[`test BaseLLM 8`] = `
-"|-
-System: this is a system message
-Human: this is a human message
+"generations:
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+    info:
+      index: 0
+llmOutput: {}
 "
 `;
 
@@ -129,115 +86,59 @@ _id:
 `;
 
 exports[`test BaseLM 2`] = `
-"{
-  "_grp": 1,
-  "_type": "constructor",
-  "_id": [
-    "input",
-    "load",
-    "msgs",
-    "BotMessage"
-  ],
-  "_kwargs": {
-    "content": "System: this is a system message\\nHuman: this is a human message"
-  }
-}"
+"generations:
+  - output: this is a prompt.
+    info:
+      index: 0
+"
 `;
 
 exports[`test BaseLM 3`] = `
-"{
-  "generations": [
-    [
-      {
-        "output": "System: this is a system message",
-        "info": {
-          "index": 0
-        }
-      },
-      {
-        "output": "Human: this is a human message",
-        "info": {
-          "index": 1
-        }
-      }
-    ],
-    [
-      {
-        "output": "AI: this is a bot message",
-        "info": {
-          "index": 0
-        }
-      }
-    ]
-  ]
-}"
+"generations:
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+      AI: this is a bot message
+    info:
+      index: 0
+"
 `;
 
 exports[`test BaseLM 4`] = `
-"{
-  "generations": [
-    [
-      {
-        "output": "this is a prompt.",
-        "info": {
-          "index": 0
-        }
-      },
-      {
-        "output": "System: this is a system message\\nHuman: this is a human message",
-        "info": {
-          "index": 1
-        }
-      }
-    ],
-    [
-      {
-        "output": "this is a prompt.",
-        "info": {
-          "index": 0
-        }
-      }
-    ]
-  ]
-}"
+"generations:
+  - output: |-
+      Human: this is a human message 1
+      Human: this is a human message 2
+      Human: this is a human message 3
+    info:
+      index: 0
+"
 `;
 
 exports[`test BaseLM 5`] = `
 "generations:
-  - - output: this is a prompt.
-      info:
-        index: 0
+  - output: this is a prompt.
+    info:
+      index: 0
 "
 `;
 
 exports[`test BaseLM 6`] = `
 "generations:
-  - - output: |-
-        System: this is a system message
-        Human: this is a human message
-        AI: this is a bot message
-      info:
-        index: 0
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+    info:
+      index: 0
 "
 `;
 
 exports[`test BaseLM 7`] = `
 "generations:
-  - - output: |-
-        Human: this is a human message 1
-        Human: this is a human message 2
-        Human: this is a human message 3
-      info:
-        index: 0
-"
-`;
-
-exports[`test BaseLM 8`] = `
-"generations:
-  - - output: |-
-        System: this is a system message
-        Human: this is a human message
-      info:
-        index: 0
+  - output: |-
+      System: this is a system message
+      Human: this is a human message
+    info:
+      index: 0
 "
 `;

--- a/packages/core/src/events/inference/chat/llms/tests/base.test.ts
+++ b/packages/core/src/events/inference/chat/llms/tests/base.test.ts
@@ -1,15 +1,11 @@
 import { expect, test } from '@jest/globals';
 import { stringify } from 'yaml';
 import { MemoryCache } from '../../../../../cache/index.js';
-import { batch } from '../../../../../utils/batch.js';
 import {
-  BaseMessage,
   BaseMessageLike,
-  BotMessage,
   HumanMessage,
   SystemMessage,
   convertMessageLikeToMessage,
-  getChatString,
 } from '../../../../input/load/msgs/base.js';
 import {
   BasePrompt,
@@ -60,85 +56,25 @@ test('test BaseLM', async () => {
     /**
      * In this method, we mock the language model result as pairs of prompts
      * given an array of prompts.
-     * @param prompts The given array of prompts in strings.
+     * @param {string} prompt - A prompt.
      * @param options if given an array of strings, then it means the stopwords.
      * @param callbacks TODO: not yet implemented
      */
     async provide(
-      prompts: string[],
+      prompt: string,
       options?: BaseLMCallOptions | string[],
       callbacks?: any
     ): Promise<LLMResult> {
-      const generations: Generation[][] = batch(prompts, 2).map(
-        (promptPair: string[]) =>
-          promptPair.map((prompt: string, idx: number) => ({
-            output: prompt,
-            info: {
-              index: idx,
-            },
-          }))
-      );
+      const generations: Generation[] = [
+        {
+          output: prompt,
+          info: {
+            index: 0,
+          },
+        },
+      ];
 
       return { generations };
-    }
-
-    /**
-     * In this method, we mock the language model result as pairs of prompts
-     * given an array of prompts.
-     * @param prompts The given array of prompts in {@link BasePrompt}.
-     * @param options if given an array of strings, then it means the stopwords.
-     * @param callbacks TODO: not yet implemented
-     */
-    async provideWithPrompts(
-      prompts: BasePrompt[],
-      options?: BaseLMCallOptions | string[],
-      callbacks?: any
-    ): Promise<LLMResult> {
-      const promptStrs: string[] = prompts.map((prompt: BasePrompt) =>
-        prompt.toString()
-      );
-
-      const generations: Generation[][] = batch(promptStrs, 2).map(
-        (promptPair: string[]) =>
-          promptPair.map((prompt: string, idx: number) => ({
-            output: prompt,
-            info: {
-              index: idx,
-            },
-          }))
-      );
-
-      return { generations };
-    }
-
-    /**
-     * In this method, we mock the predict text as the given text input.
-     * @param text The given input in string.
-     * @param options if given an array of strings, then it means the stopwords.
-     * @param callbacks TODO: not yet implemented
-     * @returns
-     */
-    async predict(
-      text: string,
-      options?: BaseLMCallOptions | string[],
-      callbacks?: any
-    ): Promise<string> {
-      return text;
-    }
-
-    /**
-     * In this method, we mock the predict text as the given text input in {@link BotMessage}.
-     * @param messages The given input in {@link BaseMessage[]}.
-     * @param options if given an array of strings, then it means the stopwords.
-     * @param callbacks TODO: not yet implemented
-     */
-    async predictWithMessages(
-      messages: BaseMessage[],
-      options?: BaseLMCallOptions | string[] | undefined,
-      callbacks?: any
-    ): Promise<BaseMessage> {
-      const text: string = getChatString(messages);
-      return new BotMessage(text);
     }
 
     /**
@@ -161,8 +97,8 @@ test('test BaseLM', async () => {
         prompt = input;
       }
 
-      const result: LLMResult = await this.provideWithPrompts(
-        [prompt],
+      const result: LLMResult = await this.provide(
+        prompt.toString(),
         options,
         options?.callbacks
       );
@@ -177,33 +113,13 @@ test('test BaseLM', async () => {
   const serializedStr: string = JSON.stringify(testLM, null, 2);
   expect(stringify(JSON.parse(serializedStr))).toMatchSnapshot();
 
-  const result: string = await testLM.predict('this is a prompt.');
-  expect(result).toBe('this is a prompt.');
-
-  const messages: BaseMessage[] = [
-    new SystemMessage('this is a system message'),
-    new HumanMessage('this is a human message'),
-  ];
-  const result2: BaseMessage = await testLM.predictWithMessages(messages);
-  expect(JSON.stringify(result2, null, 2)).toMatchSnapshot();
-
-  const prompts: string[] = [
-    'System: this is a system message',
-    'Human: this is a human message',
-    'AI: this is a bot message',
-  ];
-  const result3: LLMResult = await testLM.provide(prompts);
-  expect(JSON.stringify(result3, null, 2)).toMatchSnapshot();
-
-  const basePrompts: BasePrompt[] = [
-    new StringPrompt('this is a prompt.'),
-    new ChatPrompt(messages),
-    new StringPrompt('this is a prompt.'),
-  ];
-  const result4: LLMResult = await testLM.provideWithPrompts(basePrompts);
-  expect(JSON.stringify(result4, null, 2)).toMatchSnapshot();
+  const result: LLMResult = await testLM.provide('this is a prompt.');
+  expect(result).toStrictEqual({
+    generations: [{ info: { index: 0 }, output: 'this is a prompt.' }]
+  });
 
   expect(stringify(await testLM.invoke('this is a prompt.'))).toMatchSnapshot();
+
   expect(
     stringify(
       await testLM.invoke([
@@ -213,6 +129,7 @@ test('test BaseLM', async () => {
       ])
     )
   ).toMatchSnapshot();
+
   expect(
     stringify(
       await testLM.invoke([
@@ -222,8 +139,30 @@ test('test BaseLM', async () => {
       ])
     )
   ).toMatchSnapshot();
-  expect(stringify(await testLM.invoke(messages))).toMatchSnapshot();
 
+  expect(
+    stringify(await testLM.invoke(new StringPrompt('this is a prompt.')))
+  ).toMatchSnapshot();
+
+  expect(
+    stringify(
+      await testLM.invoke(
+        new ChatPrompt([
+          new SystemMessage('this is a system message'),
+          new HumanMessage('this is a human message'),
+        ])
+      )
+    )
+  ).toMatchSnapshot();
+
+  expect(
+    stringify(
+      await testLM.invoke([
+        new SystemMessage('this is a system message'),
+        new HumanMessage('this is a human message'),
+      ])
+    )
+  ).toMatchSnapshot();
 });
 
 test('test BaseLLM', async () => {
@@ -231,23 +170,22 @@ test('test BaseLLM', async () => {
     /**
      * In this method, we mock the language model result as pairs of prompts
      * given an array of prompts.
-     * @param prompts The given array of prompts in strings.
+     * @param {string} prompt - A prompt.
      * @param options if given an array of strings, then it means the stopwords.
      * @param callbacks TODO: not yet implemented
      */
     async _provide(
-      prompts: string[],
+      prompt: string,
       options: this['SerializedCallOptions']
     ): Promise<LLMResult> {
-      const generations: Generation[][] = batch(prompts, 2).map(
-        (promptPair: string[]) =>
-          promptPair.map((prompt: string, idx: number) => ({
-            output: prompt,
-            info: {
-              index: idx,
-            },
-          }))
-      );
+      const generations: Generation[] = [
+        {
+          output: prompt,
+          info: {
+            index: 0,
+          },
+        },
+      ];
 
       return { generations };
     }
@@ -264,36 +202,17 @@ test('test BaseLLM', async () => {
   const serializedStr: string = JSON.stringify(testLLMWithCustomCache, null, 2);
   expect(stringify(JSON.parse(serializedStr))).toMatchSnapshot();
 
-  expect(await testLLMWithCustomCache.predict('this is a prompt.')).toBe(
-    'this is a prompt.'
-  );
+  const result: LLMResult =
+    await testLLMWithCustomCache.provide('this is a prompt.');
+  expect(result).toStrictEqual({
+    generations: [{ info: { index: 0 }, output: 'this is a prompt.' }],
+    llmOutput: {},
+  });
 
-  const messages: BaseMessage[] = [
-    new SystemMessage('this is a system message'),
-    new HumanMessage('this is a human message'),
-  ];
-  const result2: BaseMessage =
-    await testLLMWithCustomCache.predictWithMessages(messages);
-  expect(JSON.stringify(result2, null, 2)).toMatchSnapshot();
+  expect(
+    stringify(await testLLMWithCustomCache.invoke('this is a prompt.'))
+  ).toMatchSnapshot();
 
-  const prompts: string[] = [
-    'System: this is a system message',
-    'Human: this is a human message',
-    'AI: this is a bot message',
-  ];
-  const result3: LLMResult = await testLLMWithCustomCache.provide(prompts);
-  expect(JSON.stringify(result3, null, 2)).toMatchSnapshot();
-
-  const basePrompts: BasePrompt[] = [
-    new StringPrompt('this is a prompt.'),
-    new ChatPrompt(messages),
-    new StringPrompt('this is a prompt.'),
-  ];
-  const result4: LLMResult =
-    await testLLMWithCustomCache.provideWithPrompts(basePrompts);
-  expect(JSON.stringify(result4, null, 2)).toMatchSnapshot();
-
-  expect(stringify(await testLLMWithCustomCache.invoke('this is a prompt.'))).toMatchSnapshot();
   expect(
     stringify(
       await testLLMWithCustomCache.invoke([
@@ -303,6 +222,7 @@ test('test BaseLLM', async () => {
       ])
     )
   ).toMatchSnapshot();
+
   expect(
     stringify(
       await testLLMWithCustomCache.invoke([
@@ -312,5 +232,30 @@ test('test BaseLLM', async () => {
       ])
     )
   ).toMatchSnapshot();
-  expect(stringify(await testLLMWithCustomCache.invoke(messages))).toMatchSnapshot();
+
+  expect(
+    stringify(
+      await testLLMWithCustomCache.invoke(new StringPrompt('this is a prompt.'))
+    )
+  ).toMatchSnapshot();
+
+  expect(
+    stringify(
+      await testLLMWithCustomCache.invoke(
+        new ChatPrompt([
+          new SystemMessage('this is a system message'),
+          new HumanMessage('this is a human message'),
+        ])
+      )
+    )
+  ).toMatchSnapshot();
+
+  expect(
+    stringify(
+      await testLLMWithCustomCache.invoke([
+        new SystemMessage('this is a system message'),
+        new HumanMessage('this is a human message'),
+      ])
+    )
+  ).toMatchSnapshot();
 });

--- a/packages/core/src/events/input/load/docs/base.ts
+++ b/packages/core/src/events/input/load/docs/base.ts
@@ -1,5 +1,5 @@
 import { Callable } from '../../../../record/callable';
-import { BaseEventParams } from '../../../base';
+import { BaseEvent, BaseEventParams } from '../../../base';
 import { Context } from './context';
 
 /**
@@ -27,7 +27,7 @@ export abstract class BaseLoader<
     CallOutput = Context[],
     CallOptions extends BaseDocLoaderCallOptions = BaseDocLoaderCallOptions,
   >
-  extends Callable<CallInput, CallOutput, CallOptions>
+  extends BaseEvent<CallInput, CallOutput, CallOptions>
   implements DocLoader<CallInput, CallOutput>
 {
   declare CallOptions: CallOptions;
@@ -37,7 +37,7 @@ export abstract class BaseLoader<
   shouldSplit?: boolean;
 
   constructor(fields?: BaseLoaderParams) {
-    super(fields);
+    super(fields ?? {});
 
     this.shouldSplit = fields?.shouldSplit ?? false;
   }

--- a/packages/core/src/events/output/provide/llmresult.ts
+++ b/packages/core/src/events/output/provide/llmresult.ts
@@ -5,9 +5,9 @@ import { Generation } from './generation';
  */
 export type LLMResult = {
   /**
-   * List of the things generated. Each input could have multiple {@link Generation}, hence this is a list of lists.
+   * One input could have multiple {@link Generation}, hence this is a list.
    */
-  generations: Generation[][];
+  generations: Generation[];
 
   /**
    * LLM-provider specific output.

--- a/packages/core/src/load/tests/__snapshots__/load.test.ts.snap
+++ b/packages/core/src/load/tests/__snapshots__/load.test.ts.snap
@@ -13,6 +13,7 @@ _kwargs:
     _type: secret
     _id:
       - TEST_API_KEY
+  should_override: a new value
   hello: 3
 "
 `;
@@ -37,6 +38,7 @@ _kwargs:
       - NEW_API_KEY
   new_attr: 42
   hello: 3
+  should_override: should override
   inherit_api_key:
     _grp: 1
     _type: secret

--- a/packages/core/src/load/tests/load.test.ts
+++ b/packages/core/src/load/tests/load.test.ts
@@ -17,12 +17,15 @@ test('test custom module serializable', async () => {
     }
 
     get _attributes(): SerializedFields | undefined {
-      return { hello: this.hello };
+      return { 
+        hello: this.hello,
+        shouldOverride: 'should override'
+      };
     }
 
     hello = 3;
 
-    constructor(fields: { aField: string; apiKey: string; hello?: number }) {
+    constructor(fields: { aField: string; apiKey: string; hello?: number, shouldOverride?: string }) {
       super(fields);
     }
   }
@@ -72,6 +75,7 @@ test('test custom module serializable', async () => {
   const test = new Test({
     aField: 'hello',
     apiKey: 'this-is-a-key',
+    shouldOverride: 'a new value'
   });
   const argumentsBefore = test._kwargs;
   const serializedStr: string = JSON.stringify(test, null, 2);


### PR DESCRIPTION
Cleaned extra functionalities in BaseLM and BaseLLM. Now it should only support `invoke` and `provide` functions to handle the LLM API calls.

Note: for any LLM that extends BaseLLM, it can add its `_provide` method to their own design of the API call. Think `invoke`, `provide` and `_provideUncached` as wrappers to the core language model integration logic in `_provide`.