### PR TITLE
add base embeddings classes

### DIFF
--- a/packages/core/src/events/embeddings/base.ts
+++ b/packages/core/src/events/embeddings/base.ts
@@ -1,0 +1,36 @@
+import {
+    AsyncCallError,
+    AsyncCaller,
+    type AsyncCallerParams,
+  } from '../../utils/asyncCaller.js';
+
+export type EmbeddingsParams = AsyncCallerParams;
+
+export abstract class Embeddings {
+    /**
+     * The async caller should be used by subclasses to make any async calls,
+     * which will thus benefit from the concurrency and retry logic.
+     */
+    caller: AsyncCaller;
+  
+    constructor(params: EmbeddingsParams) {
+      this.caller = new AsyncCaller(params ?? {});
+    }
+  
+    /**
+     * An abstract method that takes an array of documents as input and
+     * returns a promise that resolves to an array of vectors for each
+     * document.
+     * @param documents An array of documents to be embedded.
+     * @returns A promise that resolves to an array of vectors for each document.
+     */
+    abstract embedDocuments(documents: string[]): Promise<number[][]>;
+  
+    /**
+     * An abstract method that takes a single document as input and returns a
+     * promise that resolves to a vector for the query document.
+     * @param document A single document to be embedded.
+     * @returns A promise that resolves to a vector for the query document.
+     */
+    abstract embedQuery(document: string): Promise<number[]>;
+  }

--- a/packages/core/src/events/embeddings/tests/base.test.ts
+++ b/packages/core/src/events/embeddings/tests/base.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, jest} from '@jest/globals';
+import { stringify } from 'yaml';
+import {
+    Embeddings,
+    EmbeddingsParams
+} from '../base.js';
+
+
+class TestEmbeddings extends Embeddings{
+    async embedDocuments(documents: string[]): Promise<number[][]> {
+        const listOfDocuments: number[][]  = [];
+        for (const document of documents){
+            listOfDocuments.push(await this.embedQuery(document));
+        }
+        return listOfDocuments;
+    }
+
+    async embedQuery(document: string): Promise<number[]> {
+        return [Math.random(), Math.random()];
+    }
+}
+
+
+test('two methods running ok', async () => {
+   const documents = ["hello", "goodbye", "test", "its has been a pleasure"]
+   // Empty parameters for initializing TestEmbeddings =
+   const test = new TestEmbeddings({})
+   const methodSpy = jest.spyOn(test, 'embedQuery');
+   const resultsPromise = test.embedDocuments(documents)
+   const results = await resultsPromise;
+   // test whether there are four [X, y] values
+   expect(results.length  == documents.length)
+   expect(Array.isArray(results)).toBe(true); 
+   // test whetehr there are 2 elements in first element
+   for (const result of results) {
+        expect(Array.isArray(result)).toBe(true); // Check if each element is an array
+        expect(result).toHaveLength(2); // Check if each element has a length of 2
+    }
+   // test whether the method has been called
+   expect(methodSpy).toHaveBeenCalled();
+})


### PR DESCRIPTION
In packages/core/src/events/embeddings directory, 

I have added the base embedding class which contains an embed document abstract function and embed Query abstract function. 

Included a test for the base class by implementing a child class of the abstract class