### PR TITLE
Change `metadata.callables` to `getAttributes()` for callables

### DIFF
--- a/packages/core/src/load/tests/serializable.test.ts
+++ b/packages/core/src/load/tests/serializable.test.ts
@@ -191,7 +191,7 @@ describe('information stored in serializable', () => {
     get _aliases(): SerializedKeyAlias {
       return {
         attr1: 'newAttr1',
-        'sub1': 'newSub1',
+        sub1: 'newSub1',
       };
     }
 
@@ -496,25 +496,25 @@ describe('information stored in serializable', () => {
     const attrWithAliases = new AttrWithAliases({
       attr1: 999,
       attr4: {
-          sub1: 998,
-          sub2: '5',
-          sub3: true,
-          sub4: undefined,
-          sub5: null,
-      }
+        sub1: 998,
+        sub2: '5',
+        sub3: true,
+        sub4: undefined,
+        sub5: null,
+      },
     });
 
     expect(attrWithAliases.getAttributes()).toStrictEqual({
       aliases: {
         attr1: 'newAttr1',
-        'sub1': 'newSub1', // This is not used
+        sub1: 'newSub1', // This is not used
       },
       secrets: {},
       kwargs: {
         attr1: 999,
         newAttr2: '2',
         attr3: false,
-        attr4: {
+        attr4: { 
           sub1: 998, // The aliases only change keys in the root level
           sub2: '5',
           sub3: true,
@@ -563,10 +563,10 @@ describe('information stored in serializable', () => {
     expect(anotherAttrWithAliases).toBeInstanceOf(AttrWithAliases);
     expect(JSON.stringify(anotherAttrWithAliases, null, 2)).toBe(str);
 
-    expect(attrWithAliases.getAttributes()).toStrictEqual({
+    expect(anotherAttrWithAliases.getAttributes()).toStrictEqual({
       aliases: {
         attr1: 'newAttr1',
-        'sub1': 'newSub1', // This is not used
+        sub1: 'newSub1', // This is not used
       },
       secrets: {},
       kwargs: {
@@ -577,13 +577,12 @@ describe('information stored in serializable', () => {
           sub1: 998, // The aliases only change keys in the root level
           sub2: '5',
           sub3: true,
-          sub4: undefined,
+          // sub4: undefined, // This is not observed in the invoked Class
           sub5: null,
         },
         attr5: undefined,
         attr6: null,
       },
     });
-
   });
 });

--- a/packages/core/src/record/callable.ts
+++ b/packages/core/src/record/callable.ts
@@ -109,7 +109,10 @@ export type CallableBatchOptions = {
 };
 
 export type SerializedCallableFields = {
-  [key: string]: Callable | Record<string, Callable> | Array<Callable>;
+  [key: string]:
+    | ReturnType<Callable['getAttributes']>
+    | Record<string, ReturnType<Callable['getAttributes']>>
+    | Array<ReturnType<Callable['getAttributes']>>;
 };
 
 /**
@@ -682,7 +685,7 @@ export class CallableBind<
     return {
       type: 'CallableBind',
       callables: {
-        bound: this.bound,
+        bound: this.bound.getAttributes(),
       },
     };
   }
@@ -994,7 +997,9 @@ export class CallableMap<CallInput> extends Callable<
     return {
       type: 'CallableMap',
       callables: {
-        steps: this.steps,
+        steps: Object.fromEntries(
+          Object.entries(this.steps).map(([k, v]) => [k, v.getAttributes()])
+        ),
       },
     };
   }
@@ -1083,7 +1088,7 @@ export class CallableEach<
     return {
       type: 'CallableEach',
       callables: {
-        bound: this.bound,
+        bound: this.bound.getAttributes(),
       },
     };
   }
@@ -1315,8 +1320,8 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
     return {
       type: 'CallableWithFallbacks',
       callables: {
-        callable: this.callable,
-        fallbacks: this.fallbacks,
+        callable: this.callable.getAttributes(),
+        fallbacks: this.fallbacks.map((fallback) => fallback.getAttributes()),
       },
     };
   }
@@ -1619,9 +1624,9 @@ export class CallableSequence<
     return {
       type: 'CallableSequence',
       callables: {
-        first: this.first,
-        middle: this.middle,
-        last: this.last
+        first: this.first.getAttributes(),
+        middle: this.middle.map((mid) => mid.getAttributes()),
+        last: this.last.getAttributes(),
       },
     };
   }

--- a/packages/core/src/record/tests/serializable.callable.test.ts
+++ b/packages/core/src/record/tests/serializable.callable.test.ts
@@ -27,6 +27,10 @@ describe('information stored in serializable', () => {
     output2: boolean;
   }
 
+  interface CallInput {
+    input1?: string;
+  }
+
   interface SimpleCallableOptions extends CallableConfig {
     option1: string;
   }
@@ -171,7 +175,19 @@ describe('information stored in serializable', () => {
       metadata: {
         type: 'CallableBind',
         callables: {
-          bound: simpleCallable,
+          bound: {
+            aliases: {},
+            secrets: {
+              secret1: 'TEST_SECRET_1',
+            },
+            kwargs: {
+              attr1: 1,
+              attr2: '2',
+            },
+            metadata: {
+              type: 'Callable',
+            },
+          },
         },
       },
     });
@@ -230,14 +246,7 @@ describe('information stored in serializable', () => {
 
     expect(
       anotherCallableBind.getAttributes().metadata.callables?.bound
-    ).toBeInstanceOf(SimpleCallable);
-
-    const anotherSimpleCallable = anotherCallableBind.getAttributes().metadata
-      .callables?.bound as SimpleCallable;
-
-    expect(anotherSimpleCallable.attr1).toBe(1);
-    expect(anotherSimpleCallable.attr2).toBe('2');
-    expect(anotherSimpleCallable.secret1).toBe('other secret 1');
+    ).toStrictEqual(simpleCallable.getAttributes());
   });
 
   test('callableLambda', async () => {
@@ -325,9 +334,45 @@ describe('information stored in serializable', () => {
         type: 'CallableMap',
         callables: {
           steps: {
-            first: simpleCallable1,
-            second: simpleCallable2,
-            third: simpleCallable3,
+            first: {
+              aliases: {},
+              secrets: {
+                secret1: 'TEST_SECRET_1',
+              },
+              kwargs: {
+                attr1: 1,
+                attr2: '2',
+              },
+              metadata: {
+                type: 'Callable',
+              },
+            },
+            second: {
+              aliases: {},
+              secrets: {
+                secret1: 'TEST_SECRET_1',
+              },
+              kwargs: {
+                attr1: 2,
+                attr2: '2',
+              },
+              metadata: {
+                type: 'Callable',
+              },
+            },
+            third: {
+              aliases: {},
+              secrets: {
+                secret1: 'TEST_SECRET_1',
+              },
+              kwargs: {
+                attr1: 3,
+                attr2: '2',
+              },
+              metadata: {
+                type: 'Callable',
+              },
+            },
           },
         },
       },
@@ -415,34 +460,15 @@ describe('information stored in serializable', () => {
 
     expect(
       anotherCallableMap.getAttributes().metadata.callables?.steps['first']
-    ).toBeInstanceOf(SimpleCallable);
+    ).toStrictEqual(simpleCallable1.getAttributes());
+
     expect(
       anotherCallableMap.getAttributes().metadata.callables?.steps['second']
-    ).toBeInstanceOf(SimpleCallable);
+    ).toStrictEqual(simpleCallable2.getAttributes());
+
     expect(
       anotherCallableMap.getAttributes().metadata.callables?.steps['third']
-    ).toBeInstanceOf(SimpleCallable);
-
-    const firstSimpleCallable = anotherCallableMap.getAttributes().metadata
-      .callables?.steps['first'] as SimpleCallable;
-
-    expect(firstSimpleCallable.attr1).toBe(1);
-    expect(firstSimpleCallable.attr2).toBe('2');
-    expect(firstSimpleCallable.secret1).toBe('other secret 1');
-
-    const secondSimpleCallable = anotherCallableMap.getAttributes().metadata
-      .callables?.steps['second'] as SimpleCallable;
-
-    expect(secondSimpleCallable.attr1).toBe(2);
-    expect(secondSimpleCallable.attr2).toBe('2');
-    expect(secondSimpleCallable.secret1).toBe('other secret 1');
-
-    const thirdSimpleCallable = anotherCallableMap.getAttributes().metadata
-      .callables?.steps['third'] as SimpleCallable;
-
-    expect(thirdSimpleCallable.attr1).toBe(3);
-    expect(thirdSimpleCallable.attr2).toBe('2');
-    expect(thirdSimpleCallable.secret1).toBe('other secret 1');
+    ).toStrictEqual(simpleCallable3.getAttributes());
   });
 
   test('callableEach', async () => {
@@ -460,7 +486,19 @@ describe('information stored in serializable', () => {
       metadata: {
         type: 'CallableEach',
         callables: {
-          bound: simpleCallable,
+          bound: {
+            aliases: {},
+            secrets: {
+              secret1: 'TEST_SECRET_1',
+            },
+            kwargs: {
+              attr1: 1,
+              attr2: '2',
+            },
+            metadata: {
+              type: 'Callable',
+            },
+          },
         },
       },
     });
@@ -515,14 +553,7 @@ describe('information stored in serializable', () => {
 
     expect(
       anotherCallableEach.getAttributes().metadata.callables?.bound
-    ).toBeInstanceOf(SimpleCallable);
-
-    const anotherSimpleCallable = anotherCallableEach.getAttributes().metadata
-      .callables?.bound as SimpleCallable;
-
-    expect(anotherSimpleCallable.attr1).toBe(1);
-    expect(anotherSimpleCallable.attr2).toBe('2');
-    expect(anotherSimpleCallable.secret1).toBe('other secret 1');
+    ).toStrictEqual(simpleCallable.getAttributes());
   });
 
   test('callableWithFallbacks', async () => {
@@ -552,8 +583,47 @@ describe('information stored in serializable', () => {
       metadata: {
         type: 'CallableWithFallbacks',
         callables: {
-          callable: simpleCallable1,
-          fallbacks: [fallbackCallable2, fallbackCallable3],
+          callable: {
+            aliases: {},
+            secrets: {
+              secret1: 'TEST_SECRET_1',
+            },
+            kwargs: {
+              attr1: 1,
+              attr2: '2',
+            },
+            metadata: {
+              type: 'Callable',
+            },
+          },
+          fallbacks: [
+            {
+              aliases: {},
+              secrets: {
+                secret1: 'TEST_SECRET_1',
+              },
+              kwargs: {
+                attr1: 2,
+                attr2: '2',
+              },
+              metadata: {
+                type: 'Callable',
+              },
+            },
+            {
+              aliases: {},
+              secrets: {
+                secret1: 'TEST_SECRET_1',
+              },
+              kwargs: {
+                attr1: 3,
+                attr2: '2',
+              },
+              metadata: {
+                type: 'Callable',
+              },
+            },
+          ],
         },
       },
     });
@@ -633,45 +703,22 @@ describe('information stored in serializable', () => {
     expect(JSON.stringify(anotherCallableWithFallbacks, null, 2)).toBe(str);
 
     expect(
-      anotherCallableWithFallbacks.getAttributes().metadata.callables?.callable
-    ).toBeInstanceOf(SimpleCallable);
-
-    expect(
       Array.isArray(
-        anotherCallableWithFallbacks.getAttributes().metadata.callables
-          ?.fallbacks
+        anotherCallableWithFallbacks.getAttributes().metadata.callables?.fallbacks
       )
     ).toBeTruthy();
 
     expect(
-      anotherCallableWithFallbacks.getAttributes().metadata.callables
-        ?.fallbacks[0]
-    ).toBeInstanceOf(SimpleCallable);
+      anotherCallableWithFallbacks.getAttributes().metadata.callables?.callable
+    ).toStrictEqual(simpleCallable1.getAttributes());
+
     expect(
-      anotherCallableWithFallbacks.getAttributes().metadata.callables
-        ?.fallbacks[1]
-    ).toBeInstanceOf(SimpleCallable);
+      anotherCallableWithFallbacks.getAttributes().metadata.callables?.fallbacks[0]
+    ).toStrictEqual(fallbackCallable2.getAttributes());
 
-    const firstSimpleCallable = anotherCallableWithFallbacks.getAttributes()
-      .metadata.callables?.callable as SimpleCallable;
-
-    expect(firstSimpleCallable.attr1).toBe(1);
-    expect(firstSimpleCallable.attr2).toBe('2');
-    expect(firstSimpleCallable.secret1).toBe('other secret 1');
-
-    const secondSimpleCallable = anotherCallableWithFallbacks.getAttributes()
-      .metadata.callables?.fallbacks[0] as SimpleCallable;
-
-    expect(secondSimpleCallable.attr1).toBe(2);
-    expect(secondSimpleCallable.attr2).toBe('2');
-    expect(secondSimpleCallable.secret1).toBe('other secret 1');
-
-    const thirdSimpleCallable = anotherCallableWithFallbacks.getAttributes()
-      .metadata.callables?.fallbacks[1] as SimpleCallable;
-
-    expect(thirdSimpleCallable.attr1).toBe(3);
-    expect(thirdSimpleCallable.attr2).toBe('2');
-    expect(thirdSimpleCallable.secret1).toBe('other secret 1');
+    expect(
+      anotherCallableWithFallbacks.getAttributes().metadata.callables?.fallbacks[1]
+    ).toStrictEqual(fallbackCallable3.getAttributes());
   });
 
   test('callableSequence', async () => {
@@ -707,9 +754,39 @@ describe('information stored in serializable', () => {
       metadata: {
         type: 'CallableSequence',
         callables: {
-          first: simpleCallable1,
-          middle: [simpleCallable2],
-          last: simpleCallable3,
+          first: {
+            aliases: {},
+            secrets: {
+              secret1: 'TEST_SECRET_1',
+            },
+            kwargs: {
+              attr1: 1,
+              attr2: '2',
+            },
+            metadata: {
+              type: 'Callable',
+            },
+          },
+          middle: [{
+            aliases: {},
+            secrets: {},
+            kwargs: {
+              func: lambda.toString(),
+            },
+            metadata: {
+              type: 'CallableLambda',
+            },
+          }],
+          last: {
+            aliases: {},
+            secrets: {},
+            kwargs: {
+              func: lambda.toString(),
+            },
+            metadata: {
+              type: 'CallableLambda',
+            },
+          },
         },
       },
     });
@@ -777,28 +854,21 @@ describe('information stored in serializable', () => {
     expect(JSON.stringify(anotherCallableSequence, null, 2)).toBe(str);
 
     expect(
-      anotherCallableSequence.getAttributes().metadata.callables?.first
-    ).toBeInstanceOf(SimpleCallable);
-
-    expect(
       Array.isArray(
         anotherCallableSequence.getAttributes().metadata.callables?.middle
       )
     ).toBeTruthy();
 
     expect(
+      anotherCallableSequence.getAttributes().metadata.callables?.first
+    ).toStrictEqual(simpleCallable1.getAttributes());
+
+    expect(
       anotherCallableSequence.getAttributes().metadata.callables?.middle[0]
-    ).toBeInstanceOf(CallableLambda);
+    ).toStrictEqual(simpleCallable2.getAttributes());
 
     expect(
       anotherCallableSequence.getAttributes().metadata.callables?.last
-    ).toBeInstanceOf(CallableLambda);
-
-    const firstSimpleCallable = anotherCallableSequence.getAttributes().metadata
-      .callables?.first as SimpleCallable;
-
-    expect(firstSimpleCallable.attr1).toBe(1);
-    expect(firstSimpleCallable.attr2).toBe('2');
-    expect(firstSimpleCallable.secret1).toBe('other secret 1');
+    ).toStrictEqual(simpleCallable3.getAttributes());
   });
 });


### PR DESCRIPTION
Before this change, `metadata.callables` is storing the `Callable` class instance.

After the change, `metadata.callables` is storing the `getAttributes()` data from the `Callable` class instance.