### PR TITLE
Add callableIf for switching branches in a callableMap

### DIFF
--- a/packages/core/src/events/inference/validate/guardrails/base.ts
+++ b/packages/core/src/events/inference/validate/guardrails/base.ts
@@ -66,9 +66,9 @@ export abstract class BaseRule<T = any>
     return CallableLambda.from(this.func);
   }
 
-  async validate(input: T): Promise<boolean> {
-    if (this.variables) {
-      return this.func(input, this.variables);
+  async validate(input: T, variables?: Record<string, unknown>): Promise<boolean> {
+    if (variables || this.variables) {
+      return this.func(input, variables ?? this.variables);
     } else {
       return this.func(input);
     }

--- a/packages/core/src/record/callable.ts
+++ b/packages/core/src/record/callable.ts
@@ -1,4 +1,4 @@
-import { BaseRule } from '../events/inference/validate/guardrails/base.js';
+import { BaseRule } from "../events/inference/validate/guardrails/base.js";
 import {
   RecordId,
   RecordType,
@@ -8,20 +8,20 @@ import {
   keyToJson,
   mapKeyTypes,
   mapKeys,
-} from '../load/keymap.js';
+} from "../load/keymap.js";
 import {
   Serializable,
   Serialized,
   SerializedInputRecord,
-} from '../load/serializable.js';
-import { AsyncCallError, AsyncCaller } from '../utils/asyncCaller.js';
-import { shallowCopy } from '../utils/copy.js';
-import { ReadableStreamAsyncIterable } from '../utils/stream.js';
+} from "../load/serializable.js";
+import { AsyncCallError, AsyncCaller } from "../utils/asyncCaller.js";
+import { shallowCopy } from "../utils/copy.js";
+import { ReadableStreamAsyncIterable } from "../utils/stream.js";
 import {
   convertCallableLikeToCallable,
   convertLambdaFuncFromStr,
   isValidLambdaFunc,
-} from './utils.js';
+} from "./utils.js";
 
 /**
  * Type for defining fields in a callable configuration.
@@ -55,6 +55,14 @@ export type CallableConfig = {
    * TODO: Add callbacks.
    */
   callbacks?: any;
+};
+
+/**
+ * Extends `CallableConfig` with an optional `variables` record for additional configuration.
+ * @property `variables` - Additional variables for guardrail rule validation.
+ */
+export type CallableIfConfig = CallableConfig & {
+  variables?: Record<string, unknown>;
 };
 
 /**
@@ -115,12 +123,12 @@ export type CallableBatchOptions = {
 
 export type SerializedCallableFields = {
   [key: string]:
-    | ReturnType<Serializable['getAttributes']>
-    | Record<string, ReturnType<Serializable['getAttributes']>>
-    | Array<ReturnType<Serializable['getAttributes']>>
-    | ReturnType<Callable['getAttributes']>
-    | Record<string, ReturnType<Callable['getAttributes']>>
-    | Array<ReturnType<Callable['getAttributes']>>;
+    | ReturnType<Serializable["getAttributes"]>
+    | Record<string, ReturnType<Serializable["getAttributes"]>>
+    | Array<ReturnType<Serializable["getAttributes"]>>
+    | ReturnType<Callable["getAttributes"]>
+    | Record<string, ReturnType<Callable["getAttributes"]>>
+    | Array<ReturnType<Callable["getAttributes"]>>;
 };
 
 /**
@@ -409,7 +417,7 @@ export abstract class Callable<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'Callable',
+      type: "Callable",
     };
   }
 
@@ -420,7 +428,7 @@ export abstract class Callable<
     const result: SerializedFields = shallowCopy(root);
 
     for (const [path, callable] of Object.entries(callablesMap)) {
-      const [last, ...partsReverse] = path.split('.').reverse();
+      const [last, ...partsReverse] = path.split(".").reverse();
 
       let current: SerializedFields = result;
       for (const key of partsReverse.reverse()) {
@@ -433,8 +441,8 @@ export abstract class Callable<
       }
 
       if (current[last] !== undefined) {
-        if (path.split('.').length > 1) {
-          delete result[path.split('.')[0]];
+        if (path.split(".").length > 1) {
+          delete result[path.split(".")[0]];
         } else {
           delete current[last];
         }
@@ -521,10 +529,10 @@ export class CallableBind<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableBind';
+    return "CallableBind";
   }
 
   /**
@@ -561,9 +569,9 @@ export class CallableBind<
 
     if (config) {
       for (const key of Object.keys(config)) {
-        if (key === 'metadata') {
+        if (key === "metadata") {
           configCopy[key] = { ...configCopy[key], ...config[key] };
-        } else if (key === 'tags') {
+        } else if (key === "tags") {
           configCopy[key] = (configCopy[key] ?? []).concat(config[key] ?? []);
         } else {
           configCopy[key] = config[key] ?? configCopy[key];
@@ -691,7 +699,7 @@ export class CallableBind<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableBind',
+      type: "CallableBind",
       callables: {
         bound: this.bound.getAttributes(),
       },
@@ -705,7 +713,7 @@ export class CallableBind<
   ): Promise<Serialized> {
     return {
       _grp: 2,
-      _type: 'input_record',
+      _type: "input_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -726,7 +734,7 @@ export class CallableBind<
     parent?: RecordId | undefined
   ): Promise<Serialized> {
     let serializedOutputs: SerializedFields;
-    if (typeof outputs === 'object') {
+    if (typeof outputs === "object") {
       serializedOutputs = (outputs ?? {}) as SerializedFields;
     } else {
       serializedOutputs = (outputs ? { outputs } : {}) as SerializedFields;
@@ -762,7 +770,7 @@ export class CallableBind<
 
     return {
       _grp: 2,
-      _type: 'event_record',
+      _type: "event_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -810,10 +818,10 @@ export class CallableLambda<CallInput, CallOutput> extends Callable<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableLambda';
+    return "CallableLambda";
   }
 
   /**
@@ -824,9 +832,9 @@ export class CallableLambda<CallInput, CallOutput> extends Callable<
   constructor(fields: { func: CallableFunc<CallInput, CallOutput> | string }) {
     let funcStr: string | undefined;
 
-    if (typeof fields.func === 'string') {
+    if (typeof fields.func === "string") {
       if (!isValidLambdaFunc(fields.func)) {
-        throw new Error('Function Str is not valid');
+        throw new Error("Function Str is not valid");
       }
 
       funcStr = fields.func;
@@ -879,7 +887,7 @@ export class CallableLambda<CallInput, CallOutput> extends Callable<
     try {
       output = await this._func()(input);
     } catch {
-      throw new Error('Function is not valid');
+      throw new Error("Function is not valid");
     }
 
     if (output && Callable.isCallable(output)) {
@@ -908,7 +916,7 @@ export class CallableLambda<CallInput, CallOutput> extends Callable<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableLambda',
+      type: "CallableLambda",
     };
   }
 }
@@ -928,10 +936,10 @@ export class CallableMap<CallInput> extends Callable<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableMap';
+    return "CallableMap";
   }
 
   /**
@@ -994,7 +1002,7 @@ export class CallableMap<CallInput> extends Callable<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableMap',
+      type: "CallableMap",
       callables: {
         steps: Object.fromEntries(
           Object.entries(this.steps).map(([k, v]) => [k, v.getAttributes()])
@@ -1022,10 +1030,10 @@ export class CallableEach<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableEach';
+    return "CallableEach";
   }
 
   /**
@@ -1085,7 +1093,7 @@ export class CallableEach<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableEach',
+      type: "CallableEach",
       callables: {
         bound: this.bound.getAttributes(),
       },
@@ -1099,7 +1107,7 @@ export class CallableEach<
   ): Promise<Serialized> {
     return {
       _grp: 2,
-      _type: 'input_record',
+      _type: "input_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -1140,7 +1148,7 @@ export class CallableEach<
 
     return {
       _grp: 2,
-      _type: 'event_record',
+      _type: "event_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -1182,14 +1190,14 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
   CallInput,
   CallOutput
 > {
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   _isCallable = true;
 
   _isSerializable = true;
 
   static _name(): string {
-    return 'CallableWithFallbacks';
+    return "CallableWithFallbacks";
   }
 
   /**
@@ -1248,7 +1256,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
     }
 
     if (firstError === undefined) {
-      throw new Error('Fallbacks end without Error stored.');
+      throw new Error("Fallbacks end without Error stored.");
     }
 
     throw firstError;
@@ -1306,7 +1314,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
     }
 
     if (firstError === undefined) {
-      throw new Error('Fallbacks end without Error stored.');
+      throw new Error("Fallbacks end without Error stored.");
     }
 
     throw firstError;
@@ -1317,7 +1325,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableWithFallbacks',
+      type: "CallableWithFallbacks",
       callables: {
         callable: this.callable.getAttributes(),
         fallbacks: this.fallbacks.map((fallback) => fallback.getAttributes()),
@@ -1332,7 +1340,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
   ): Promise<Serialized> {
     return {
       _grp: 2,
-      _type: 'input_record',
+      _type: "input_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -1353,7 +1361,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
     parent?: RecordId | undefined
   ): Promise<Serialized> {
     let serializedOutputs: SerializedFields;
-    if (typeof outputs === 'object') {
+    if (typeof outputs === "object") {
       serializedOutputs = (outputs ?? {}) as SerializedFields;
     } else {
       serializedOutputs = (outputs ? { outputs } : {}) as SerializedFields;
@@ -1382,7 +1390,7 @@ export class CallableWithFallbacks<CallInput, CallOutput> extends Callable<
 
     return {
       _grp: 2,
-      _type: 'event_record',
+      _type: "event_record",
       _id: this._id,
       _recordId: this._recordId,
       _kwargs: mapKeys(
@@ -1429,10 +1437,10 @@ export class CallableSequence<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableSequence';
+    return "CallableSequence";
   }
 
   /**
@@ -1621,7 +1629,7 @@ export class CallableSequence<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableSequence',
+      type: "CallableSequence",
       callables: {
         first: this.first.getAttributes(),
         middle: this.middle.map((mid) => mid.getAttributes()),
@@ -1631,10 +1639,18 @@ export class CallableSequence<
   }
 }
 
-export type CallableIfConfig = CallableConfig & {
-  variables?: Record<string, unknown>;
-};
-
+/**
+ * {@link CallableIf} class extends {@link Callable} class for mapping multiple Callable
+ * instances based on a set of rules.
+ * It allows the execution of multiple callables in parallel and aggregates their results.
+ * If the rule validation does not pass for a certain callable, then the callable will not
+ * be executed and returns `undefined` as the result.
+ *
+ * Generics:
+ * - `CallInput`: The input type for the callable.
+ * - `CallOutput`: The output type for the callable, defaults to a record.
+ * - `CallOptions`: The options type for the callable, extends `CallableIfConfig`.
+ */
 export class CallableIf<
   CallInput,
   CallOutput extends Record<string, unknown> = Record<string, unknown>,
@@ -1646,16 +1662,25 @@ export class CallableIf<
 
   _isSerializable = true;
 
-  _namespace: string[] = ['record', 'callable'];
+  _namespace: string[] = ["record", "callable"];
 
   static _name(): string {
-    return 'CallableIf';
+    return "CallableIf";
   }
 
   protected _rules: Record<string, BaseRule>;
 
   protected _actions: Record<string, Callable<CallInput>>;
 
+  /**
+   * Initializes a new instance of `CallableIf` with the given rules and actions.
+   * @param {Object} fields - The rules and actions for the instance.
+   * @param {Record<string, BaseRule>} fields.rules - A mapping of guardrail identifiers 
+   * to `BaseRule` instances.
+   * @param {Record<string, CallableLike<CallInput>>} fields.actions - A mapping of action 
+   * identifiers to `CallableLike` instances.
+   * @throws Will throw an error if an action does not have a corresponding rule.
+   */
   constructor(fields: {
     rules: Record<string, BaseRule>;
     actions: Record<string, CallableLike<CallInput>>;
@@ -1674,6 +1699,14 @@ export class CallableIf<
     }
   }
 
+  /**
+   * Creates a new `CallableIf` instance from the specified rules and actions.
+   * @static
+   * @param {Record<string, BaseRule>} rules - The rules for the callable instance.
+   * @param {Record<string, CallableLike<CallInput>>} actions - The actions for the 
+   * callable instance.
+   * @returns {CallableIf<CallInput>} A new instance of `CallableIf`.
+   */
   static from<CallInput>(
     rules: Record<string, BaseRule>,
     actions: Record<string, CallableLike<CallInput>>
@@ -1681,6 +1714,14 @@ export class CallableIf<
     return new CallableIf<CallInput>({ rules, actions });
   }
 
+  /**
+   * Invokes the callable, evaluating each rule against the input and executing the 
+   * corresponding action if the rule is true.
+   * @async
+   * @param {CallInput} input - The input to evaluate rules against and pass to actions.
+   * @param {Partial<CallOptions>} [options] - Optional configuration for the invocation.
+   * @returns {Promise<CallOutput>} The result of the action executions.
+   */
   async invoke(
     input: CallInput,
     options?: Partial<CallOptions> | undefined
@@ -1717,7 +1758,7 @@ export class CallableIf<
     callables?: SerializedCallableFields;
   } {
     return {
-      type: 'CallableIf',
+      type: "CallableIf",
       callables: {
         rules: Object.fromEntries(
           Object.entries(this._rules).map(([k, v]) => [k, v.getAttributes()])
@@ -1731,10 +1772,10 @@ export class CallableIf<
 
   private _splitCallIfOptionsFromConfig(
     options: Partial<CallOptions> = {}
-  ): [CallableConfig, this['CallIfOptions']] {
+  ): [CallableConfig, this["CallIfOptions"]] {
     const [callOptions, callIfOptions] =
       super._splitCallableOptionsFromCallOptions(options);
 
-    return [callOptions, callIfOptions as this['CallIfOptions']];
+    return [callOptions, callIfOptions as this["CallIfOptions"]];
   }
 }


### PR DESCRIPTION
### Adding `CallableIf` class to the callable ecosystem

The `CallableIf` allows users to define complex logic flows by executing specific callables based on dynamic conditions. The logic flow is very similar to `CallableMap`, which is firstly validating the input with pre-defined conditions in prallel, then executing the callables in parallel (if the validation does not pass for a certain, then the callable will not be executed and return `undefined`).

#### What does `CallableIf` do?
`CallableIf` is designed to orchestrate the execution of multiple callable tasks, each with its own set of preconditions. It evaluates these conditions and decides whether or not a particular callable should be executed. This means you can now set up a series of "if this, then that" rules for executing tasks, making the callable workflow more adaptable.

#### Key Features
- **Conditional Execution**: Only runs callables whose preconditions are met, making our processes more efficient.
- **Generic Implementation**: Works with any type of callable and input/output formats, ensuring broad applicability across our system.
- **Error Handling**: Ensures every callable has a matching rule; otherwise, it raises an error, preventing runtime error.

#### Use cases
- Init `CallableIf`:
```TypeScript
type TestInput = {
  input: string | boolean;
};

const isStringRule = new GeneralRule({
  description: 'is string',
  func: async (input: { input: TestInput }) => {
    return typeof input.input === 'string';
  },
});

const isJohnRule = new GeneralRule({
  description: 'is John',
  func: async (input: { input: TestInput }) => {
    return String(input.input) === 'John';
  },
});


type TestOutputA = string;

type TestOutputB = Array<string>;

const handlerFunc = async (input: TestInput): Promise<TestOutputA> => {
  return new Promise((resovle, reject) => resovle(String(input.input)));
};

const handlerFunc2 = async (input: TestInput): Promise<TestOutputB> => {
  return new Promise((resovle, reject) => resovle([String(input.input)]));
};

const callableLambdaA = new CallableLambda<TestInput, TestOutputA>({
  func: handlerFunc,
});

const callableLambdaB = new CallableLambda<TestInput, TestOutputB>({
  func: handlerFunc2,
});

const callableIf = CallableIf.from<TestInput>(
  {
    'if input is a string': isStringRule,
    'if input is equal to "John"': isJohnRule,
  },
  {
    'if input is a string': callableLambdaA,
    'if input is equal to "John"': callableLambdaB,
  }
);
```

- Invoke `CallableIf`
```TypeScript
const resultA = await callableIf.invoke({ input: 'input' });
// {
//   'if input is a string': 'input',
//   'if input is equal to "John"': undefined,
// }

const resultB = await callableIf.invoke({ input: 'John' });
// {
//   'if input is a string': 'John',
//   'if input is equal to "John"': ['John'],
// }

const resultC = await callableIf.invoke({ input: true });
// {
//   'if input is a string': undefined,
//   'if input is equal to "John"': undefined,
// }
```
