### PR TITLE
Bug-fixing in Encre Core

### DIFF
--- a/packages/core/src/studio/utils/display.ts
+++ b/packages/core/src/studio/utils/display.ts
@@ -170,7 +170,7 @@ function partitionDataGroup(
     const [key, data] = dataGrp[i];
 
     // skip if data is undefined
-    if (!data || !data.value) continue;
+    if (!data) continue;
 
     // if currGrp is empty or current element is of the same type as the previous one
     // (here we only care about whether the element can be displayed in the same UI (e.g.

--- a/packages/core/src/studio/utils/tests/display.test.ts
+++ b/packages/core/src/studio/utils/tests/display.test.ts
@@ -223,6 +223,7 @@ attr4: {
   "sub1": 1,
   "sub2": "2"
 }
+attr5: undefined
 attr6: `,
         language,
         keywords,
@@ -486,6 +487,7 @@ attr4: [
     "sub4": "4"
   }
 ]
+attr5: undefined
 attr6: `,
         language,
         keywords,


### PR DESCRIPTION
Fixing following bugs:
- When creating `NodeImpl` from `globalNodeRegistry`, encountered error `data has no function getAttributes`;
- When creating UIContexts from displayUIFromDataFields, no UIContexts are created due to the first data entry is a type of `UnknownData`; This fix will display the 'UnknownData', even if the data is undefined.