### PR TITLE
fix node registration `createDynamicImpl` need to re-load data every time

### DIFF
--- a/packages/core/src/events/embeddings/tests/openai.int.test.ts
+++ b/packages/core/src/events/embeddings/tests/openai.int.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 import { OpenAIEmbeddings } from '../openai';
 
 describe('OpenAIEmbeddings', () => {
-  const OPENAI_API_KEY = 'you_should_get_this_api_from_openai';
+  const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
   test('test text-embedding-ada-002', async () => {
     const openaiEmbeddings = new OpenAIEmbeddings({

--- a/packages/core/src/events/inference/chat/llms/openai/tests/chat.int.test.ts
+++ b/packages/core/src/events/inference/chat/llms/openai/tests/chat.int.test.ts
@@ -15,12 +15,12 @@ import {
 } from '../index.js';
 
 describe('OpenAIChat', () => {
-  const OPENAI_API_KEY = 'you_should_get_this_api_from_openai';
+  const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
   test('test OpenAIChat text', async () => {
     const openaiChat = new OpenAIChat({
       openAIApiKey: OPENAI_API_KEY,
-      modelName: 'gpt-4-turbo-preview',
+      modelName: 'gpt-4o-mini',
     });
 
     const messages = [new HumanMessage('Hello! Who are you?')];

--- a/packages/core/src/events/inference/chat/llms/vertexai/gemini/tests/chat.int.test.ts
+++ b/packages/core/src/events/inference/chat/llms/vertexai/gemini/tests/chat.int.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from '@jest/globals';
 import { HumanMessage } from '../../../../../../input/load/msgs/human.js';
 import { GeminiChat } from '../chat.js';
 
-const GOOGLE_API_KEY = 'you_should_get_this_api_from_google_cloud';
+const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
 
 test('test GeminiChat text', async () => {
   const gemini = new GeminiChat({

--- a/packages/core/src/events/inference/chat/llms/vertexai/gemini/tests/text.int.test.ts
+++ b/packages/core/src/events/inference/chat/llms/vertexai/gemini/tests/text.int.test.ts
@@ -4,12 +4,13 @@ import { expect, test } from '@jest/globals';
 import { HumanMessage } from '../../../../../../input/load/msgs/human.js';
 import { Gemini } from '../text.js';
 
-const GOOGLE_API_KEY = 'you_should_get_this_api_from_google_cloud';
+const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
 
 test('test Gemini simple text', async () => {
   const gemini = new Gemini({
     googleApiKey: GOOGLE_API_KEY,
     modelName: 'gemini-pro',
+    streaming: false,
   });
 
   const llmResult = await gemini.invoke(

--- a/packages/core/src/studio/graph.ts
+++ b/packages/core/src/studio/graph.ts
@@ -228,6 +228,10 @@ export abstract class BaseGraph extends Serializable implements NodeGraph {
     this.graphOutputNameMap = outputNameMap;
     this.graphEndNodeIds = endNodeIds;
 
+    this._loadLookUpTables();
+  }
+
+  private _loadLookUpTables(): void {
     // Create nodeImpl-map and node-map for future lookup
     for (const node of this.flattenNodes) {
       this.nodeMap[node.id] = node;

--- a/packages/core/src/studio/nodes/utility/graph.node.ts
+++ b/packages/core/src/studio/nodes/utility/graph.node.ts
@@ -197,12 +197,11 @@ export class SubGraphNodeImpl extends GraphNodeImpl {
       throw new Error(`CANNOT deserialize this type in graph node: ${type}`);
     }
 
-    const { SubGraph } = await import('../../graph.js');
     (data as SerializedConstructor)._kwargs['registry'] = registry?.nodes;
     const subGraphStr = JSON.stringify(data);
     const subGraph = await load<SubGraph>(subGraphStr, globalSecretMap, {
       ...globalImportMap,
-      'studio/graph': SubGraph,
+      'studio/graph': await import('../../graph.js'),
     });
 
     return {


### PR DESCRIPTION
Issue Occurs at `BaseGraph`:

- Before creating the lookup tables in the graph, it calls `createDynamicImpl` to get the NodeImpl from nodes. However, re-load node's data needs to be async, which cause the lookup table to be empty.

Solution:

- Since re-loading is not required in graph initialization, `createDynamicImpl` does not reuqire re-loading data anymore. The original function is moved to `createDynamicLoadImpl`.