### PR TITLE
Issue#115: Need to put wires behind nodes in Workflow Editor

### DIFF
--- a/packages/app/src/components/NodeCanvas.tsx
+++ b/packages/app/src/components/NodeCanvas.tsx
@@ -69,7 +69,7 @@ import { DraggableNode } from './DraggableNode';
 import { MouseIcon } from './MouseIcon';
 import { VisualComment } from './VisualComment';
 import { VisualNode } from './VisualNode';
-import { WireLayer } from './WireLayer';
+import { WireConnectionLayer, WireDraggingLayer } from './WireLayer';
 
 const styles = css`
   position: relative;
@@ -717,6 +717,13 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
           }}
         >
           <MouseIcon />
+          <WireConnectionLayer
+            connections={connections}
+            portPositions={portPositions}
+            highlightedNodeIds={selectingUniqueNodeIds}
+            highlightedPort={hoveringPort}
+            onWiresSelect={onWiresSelect}
+          />
           <div
             className="canvas-contents"
             style={{
@@ -836,14 +843,10 @@ export const NodeCanvas: FC<NodeCanvasProps> = ({
               </div>
             </DragOverlay>
           </div>
-          <WireLayer
-            connections={connections}
+          <WireDraggingLayer
             portPositions={portPositions}
             draggingWire={draggingWire}
             isDraggingFromNode={nodesToDrag.length > 0}
-            highlightedNodeIds={selectingUniqueNodeIds}
-            highlightedPort={hoveringPort}
-            onWiresSelect={onWiresSelect}
           />
           <CSSTransition
             classNames="context-menu-box"

--- a/packages/app/src/types/wire.type.ts
+++ b/packages/app/src/types/wire.type.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, ReactElement } from 'react';
 
 import { PartialConnection } from './nodeconnection.type';
 import { HighlightedPort, PortPositons } from './port.type';
@@ -31,6 +31,21 @@ export type WireLayerProps = {
   highlightedPort?: HighlightedPort;
   // selectingWireIds?: string[];
   onWiresSelect?: (wireId: string[], isMulti?: boolean) => void;
+};
+
+export type WireConnectionLayerProps = {
+  connections: NodeConnection[];
+  portPositions: PortPositons;
+  highlightedNodeIds?: RecordId[];
+  highlightedPort?: HighlightedPort;
+  // selectingWireIds?: string[];
+  onWiresSelect?: (wireId: string[], isMulti?: boolean) => void;
+};
+
+export type WireDraggingLayerProps = {
+  portPositions: PortPositons;
+  draggingWire?: Wire;
+  isDraggingFromNode?: boolean;
 };
 
 export type RenderedWireProps = {


### PR DESCRIPTION
Solution: split wire layer for displaying before the nodes and behind the nodes. When user is dragging the wire, it is showing before the nodes (see `WireDraggingLayer`). Otherwise, the already-connected wires are displaying behind the nodes (see `WireConnectionLayer`). The `WireLayer` is keeping the original function, where both dragging wires and connected wires are rendered together in a single layer.

Before this PR:
<img width="757" alt="Before" src="https://github.com/user-attachments/assets/32d2df4a-c141-4b02-a683-e56115327f22">

After this PR:
<img width="757" alt="After" src="https://github.com/user-attachments/assets/86ad4622-40d4-4637-8a16-859132152859">
